### PR TITLE
Decoupling KurentoSessionManager to support MediaMode.RELAYED

### DIFF
--- a/openvidu-server/src/main/java/io/openvidu/server/OpenViduServer.java
+++ b/openvidu-server/src/main/java/io/openvidu/server/OpenViduServer.java
@@ -25,6 +25,8 @@ import java.util.List;
 import javax.annotation.PostConstruct;
 import javax.ws.rs.ProcessingException;
 
+import io.openvidu.server.core.SessionStorage;
+import io.openvidu.server.core.Utils;
 import org.kurento.jsonrpc.JsonUtils;
 import org.kurento.jsonrpc.internal.server.config.JsonRpcConfiguration;
 import org.kurento.jsonrpc.server.JsonRpcConfigurer;
@@ -152,6 +154,14 @@ public class OpenViduServer implements JsonRpcConfigurer {
 	public CoturnCredentialsService coturnCredentialsService() {
 		return new CoturnCredentialsServiceFactory(openviduConfig()).getCoturnCredentialsService();
 	}
+
+	@Bean
+	@ConditionalOnMissingBean
+	public SessionStorage sessionStorage() { return new SessionStorage(); }
+
+	@Bean
+	@ConditionalOnMissingBean
+	public Utils utils() { return new Utils(); }
 
 	@Override
 	public void registerJsonRpcHandlers(JsonRpcHandlerRegistry registry) {

--- a/openvidu-server/src/main/java/io/openvidu/server/OpenViduServer.java
+++ b/openvidu-server/src/main/java/io/openvidu/server/OpenViduServer.java
@@ -25,6 +25,7 @@ import java.util.List;
 import javax.annotation.PostConstruct;
 import javax.ws.rs.ProcessingException;
 
+import io.openvidu.server.core.SessionManagerProvider;
 import io.openvidu.server.core.SessionStorage;
 import io.openvidu.server.core.Utils;
 import org.kurento.jsonrpc.JsonUtils;
@@ -162,6 +163,10 @@ public class OpenViduServer implements JsonRpcConfigurer {
 	@Bean
 	@ConditionalOnMissingBean
 	public Utils utils() { return new Utils(); }
+
+	@Bean
+	@ConditionalOnMissingBean
+	public SessionManagerProvider sessionManagerProvider() { return new SessionManagerProvider(); }
 
 	@Override
 	public void registerJsonRpcHandlers(JsonRpcHandlerRegistry registry) {

--- a/openvidu-server/src/main/java/io/openvidu/server/core/SessionManager.java
+++ b/openvidu-server/src/main/java/io/openvidu/server/core/SessionManager.java
@@ -189,15 +189,7 @@ public abstract class SessionManager {
 	}
 
 	public boolean isModeratorInSession(String sessionId, Participant participant) {
-		if (!this.isInsecureParticipant(participant.getParticipantPrivateId())) {
-			if (this.sessionidParticipantpublicidParticipant.get(sessionId) != null) {
-				return ParticipantRole.MODERATOR.equals(participant.getToken().getRole());
-			} else {
-				return false;
-			}
-		} else {
-			return true;
-		}
+		return this.sessionStorage.isModeratorInSession(sessionId, participant);
 	}
 
 	public boolean isInsecureParticipant(String participantPrivateId) {

--- a/openvidu-server/src/main/java/io/openvidu/server/core/SessionManagerProvider.java
+++ b/openvidu-server/src/main/java/io/openvidu/server/core/SessionManagerProvider.java
@@ -1,0 +1,30 @@
+package io.openvidu.server.core;
+
+import io.openvidu.java.client.MediaMode;
+import io.openvidu.java.client.SessionProperties;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import javax.xml.ws.spi.WebServiceFeatureAnnotation;
+
+public class SessionManagerProvider {
+
+    @Autowired
+    private SessionManager sessionManager;
+
+    @Autowired
+    private SessionStorage sessionStorage;
+
+    public SessionManager get(MediaMode mediaMode) {
+        if(mediaMode == MediaMode.RELAYED) {
+            // Implement SessionManager for MediaMode.RELAYED
+        }
+
+        return this.sessionManager;
+    }
+
+    public SessionManager get(String sessionId) {
+        SessionProperties sessionProperties = this.sessionStorage.getSessionProperties(sessionId);
+        return this.get(sessionProperties.mediaMode());
+    }
+
+}

--- a/openvidu-server/src/main/java/io/openvidu/server/core/SessionStorage.java
+++ b/openvidu-server/src/main/java/io/openvidu/server/core/SessionStorage.java
@@ -1,0 +1,307 @@
+package io.openvidu.server.core;
+
+import io.openvidu.client.OpenViduException;
+import io.openvidu.client.internal.ProtocolElements;
+import io.openvidu.java.client.SessionProperties;
+import io.openvidu.server.OpenViduServer;
+import io.openvidu.server.coturn.CoturnCredentialsService;
+import io.openvidu.server.coturn.TurnCredentials;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+public class SessionStorage {
+
+    private static final Logger log = LoggerFactory.getLogger(SessionStorage.class);
+
+    @Autowired
+    private Utils utils;
+
+    @Autowired
+    private CoturnCredentialsService coturnCredentialsService;
+
+    protected ConcurrentMap<String, Session> sessions = new ConcurrentHashMap<>();
+    protected ConcurrentMap<String, SessionProperties> sessionProperties = new ConcurrentHashMap<>();
+    protected ConcurrentMap<String, ConcurrentHashMap<String, Participant>> sessionidParticipantpublicidParticipant = new ConcurrentHashMap<>();
+    protected ConcurrentMap<String, Boolean> insecureUsers = new ConcurrentHashMap<>();
+    protected ConcurrentMap<String, ConcurrentHashMap<String, Token>> sessionidTokenTokenobj = new ConcurrentHashMap<>();
+
+    /**
+     * Returns a Session given its id
+     *
+     * @return Session
+     */
+    public Session getSession(String sessionId) {
+        return sessions.get(sessionId);
+    }
+
+    /**
+     * Returns all currently active (opened) sessions.
+     *
+     * @return set of the session's identifiers
+     */
+    public Set<String> getSessions() {
+        return new HashSet<String>(sessions.keySet());
+    }
+
+    /**
+     * Returns all currently active (opened) sessions.
+     *
+     * @return set of the session's identifiers
+     */
+    public Collection<Session> getSessionObjects() {
+        return sessions.values();
+    }
+
+    public Session putSessionIfAbsent(String sessionId, Session session) { return sessions.putIfAbsent(sessionId, session); }
+
+    public SessionProperties getSessionProperties(String sessionId) { return this.sessionProperties.get(sessionId); }
+
+    /**
+     * Returns all the participants inside a session.
+     *
+     * @param sessionId
+     *            identifier of the session
+     * @return set of {@link Participant}
+     * @throws OpenViduException
+     *             in case the session doesn't exist
+     */
+    public Set<Participant> getParticipants(String sessionId) throws OpenViduException {
+        Session session = sessions.get(sessionId);
+        if (session == null) {
+            throw new OpenViduException(OpenViduException.Code.ROOM_NOT_FOUND_ERROR_CODE, "Session '" + sessionId + "' not found");
+        }
+        Set<Participant> participants = session.getParticipants();
+        participants.removeIf(p -> p.isClosed());
+        return participants;
+    }
+
+    /**
+     * Returns a participant in a session
+     *
+     * @param sessionId
+     *            identifier of the session
+     * @param participantPrivateId
+     *            private identifier of the participant
+     * @return {@link Participant}
+     * @throws OpenViduException
+     *             in case the session doesn't exist or the participant doesn't
+     *             belong to it
+     */
+    public Participant getParticipant(String sessionId, String participantPrivateId) throws OpenViduException {
+        Session session = sessions.get(sessionId);
+        if (session == null) {
+            throw new OpenViduException(OpenViduException.Code.ROOM_NOT_FOUND_ERROR_CODE, "Session '" + sessionId + "' not found");
+        }
+        Participant participant = session.getParticipantByPrivateId(participantPrivateId);
+        if (participant == null) {
+            throw new OpenViduException(OpenViduException.Code.USER_NOT_FOUND_ERROR_CODE,
+                    "Participant '" + participantPrivateId + "' not found in session '" + sessionId + "'");
+        }
+        return participant;
+    }
+
+    /**
+     * Returns a participant
+     *
+     * @param participantPrivateId
+     *            private identifier of the participant
+     * @return {@link Participant}
+     * @throws OpenViduException
+     *             in case the participant doesn't exist
+     */
+    public Participant getParticipant(String participantPrivateId) throws OpenViduException {
+        for (Session session : sessions.values()) {
+            if (!session.isClosed()) {
+                if (session.getParticipantByPrivateId(participantPrivateId) != null) {
+                    return session.getParticipantByPrivateId(participantPrivateId);
+                }
+            }
+        }
+        throw new OpenViduException(OpenViduException.Code.USER_NOT_FOUND_ERROR_CODE,
+                "No participant with private id '" + participantPrivateId + "' was found");
+    }
+
+    public void storeSessionId(String sessionId, SessionProperties sessionProperties) {
+        this.sessionidParticipantpublicidParticipant.putIfAbsent(sessionId, new ConcurrentHashMap<>());
+        this.sessionProperties.putIfAbsent(sessionId, sessionProperties);
+        showTokens();
+    }
+
+    public ConcurrentHashMap<String, Token> putTokenObject(String  sessionId, ConcurrentHashMap<String, Token> map) {
+        return this.sessionidTokenTokenobj.putIfAbsent(sessionId, map);
+    }
+
+    public void removeTokenObject(String sessionId) {
+        this.sessionidTokenTokenobj.remove(sessionId);
+    }
+
+    public ConcurrentHashMap<String, Token> getTokenObject(String sessionId) {
+        return this.sessionidTokenTokenobj.get(sessionId);
+    }
+
+    public String newToken(String sessionId, ParticipantRole role, String serverMetadata) throws OpenViduException {
+        ConcurrentHashMap<String, Token> map = this.putTokenObject(sessionId, new ConcurrentHashMap<>());
+
+        if (map != null) {
+
+            if (!utils.isMetadataFormatCorrect(serverMetadata)) {
+                log.error("Data invalid format. Max length allowed is 10000 chars");
+                throw new OpenViduException(OpenViduException.Code.GENERIC_ERROR_CODE,
+                        "Data invalid format. Max length allowed is 10000 chars");
+            }
+
+            String token = OpenViduServer.publicUrl;
+            token += "?sessionId=" + sessionId;
+            token += "&token=" + utils.generateRandomChain();
+            token += "&role=" + role.name();
+            TurnCredentials turnCredentials = null;
+            if (this.coturnCredentialsService.isCoturnAvailable()) {
+                turnCredentials = coturnCredentialsService.createUser();
+                if (turnCredentials != null) {
+                    token += "&turnUsername=" + turnCredentials.getUsername();
+                    token += "&turnCredential=" + turnCredentials.getCredential();
+                }
+            }
+            Token t = new Token(token, role, serverMetadata, turnCredentials);
+
+            map.putIfAbsent(token, t);
+            this.showTokens();
+            return token;
+
+        } else {
+            this.removeTokenObject(sessionId);
+            log.error("sessionId [" + sessionId + "] is not valid");
+            throw new OpenViduException(OpenViduException.Code.ROOM_NOT_FOUND_ERROR_CODE, "sessionId [" + sessionId + "] not found");
+        }
+    }
+
+    public boolean isTokenValidInSession(String token, String sessionId, String participanPrivatetId) {
+        if (!this.isInsecureParticipant(participanPrivatetId)) {
+            if (this.sessionidTokenTokenobj.get(sessionId) != null) {
+                return this.sessionidTokenTokenobj.get(sessionId).containsKey(token);
+            } else {
+                return false;
+            }
+        } else {
+            this.sessionidParticipantpublicidParticipant.putIfAbsent(sessionId, new ConcurrentHashMap<>());
+            this.sessionidTokenTokenobj.putIfAbsent(sessionId, new ConcurrentHashMap<>());
+            this.sessionidTokenTokenobj.get(sessionId).putIfAbsent(token,
+                    new Token(token, ParticipantRole.PUBLISHER, "",
+                            this.coturnCredentialsService.isCoturnAvailable()
+                                    ? this.coturnCredentialsService.createUser()
+                                    : null));
+            return true;
+        }
+    }
+
+    public boolean isParticipantInSession(String sessionId, Participant participant) {
+        Session session = this.sessions.get(sessionId);
+        if (session != null) {
+            return (session.getParticipantByPrivateId(participant.getParticipantPrivateId()) != null);
+        } else {
+            throw new OpenViduException(OpenViduException.Code.ROOM_NOT_FOUND_ERROR_CODE, "[" + sessionId + "] is not a valid sessionId");
+        }
+    }
+
+    public boolean isPublisherInSession(String sessionId, Participant participant) {
+        if (!this.isInsecureParticipant(participant.getParticipantPrivateId())) {
+            if (this.sessionidParticipantpublicidParticipant.get(sessionId) != null) {
+                return (ParticipantRole.PUBLISHER.equals(participant.getToken().getRole())
+                        || ParticipantRole.MODERATOR.equals(participant.getToken().getRole()));
+            } else {
+                return false;
+            }
+        } else {
+            return true;
+        }
+    }
+
+    public boolean isInsecureParticipant(String participantPrivateId) {
+        if (this.insecureUsers.containsKey(participantPrivateId)) {
+            log.info("The user with private id {} is an INSECURE user", participantPrivateId);
+            return true;
+        }
+        return false;
+    }
+
+    public void newInsecureParticipant(String participantPrivateId) {
+        this.insecureUsers.put(participantPrivateId, true);
+    }
+
+    public void removeInsecureParticipant(String participantPrivateId) {
+        this.insecureUsers.remove(participantPrivateId);
+    }
+
+    public ConcurrentHashMap<String, Participant> getPublicIdParticipantMap(String sessionId) {
+        return this.sessionidParticipantpublicidParticipant.get(sessionId);
+    }
+
+    public Participant newParticipant(String sessionId, String participantPrivatetId, Token token,
+                                      String clientMetadata) {
+        if (this.sessionidParticipantpublicidParticipant.get(sessionId) != null) {
+            String participantPublicId = utils.generateRandomChain();
+            Participant p = new Participant(participantPrivatetId, participantPublicId, token, clientMetadata);
+            while (this.sessionidParticipantpublicidParticipant.get(sessionId).putIfAbsent(participantPublicId,
+                    p) != null) {
+                participantPublicId = utils.generateRandomChain();
+                p.setParticipantPublicId(participantPublicId);
+            }
+            return p;
+        } else {
+            throw new OpenViduException(OpenViduException.Code.ROOM_NOT_FOUND_ERROR_CODE, sessionId);
+        }
+    }
+
+    public Participant newRecorderParticipant(String sessionId, String participantPrivatetId, Token token,
+                                              String clientMetadata) {
+        if (this.sessionidParticipantpublicidParticipant.get(sessionId) != null) {
+            Participant p = new Participant(participantPrivatetId, ProtocolElements.RECORDER_PARTICIPANT_PUBLICID,
+                    token, clientMetadata);
+            this.sessionidParticipantpublicidParticipant.get(sessionId)
+                    .put(ProtocolElements.RECORDER_PARTICIPANT_PUBLICID, p);
+            return p;
+        } else {
+            throw new OpenViduException(OpenViduException.Code.ROOM_NOT_FOUND_ERROR_CODE, sessionId);
+        }
+    }
+
+    public Token consumeToken(String sessionId, String participantPrivateId, String token) {
+        if (this.sessionidTokenTokenobj.get(sessionId) != null) {
+            Token t = this.sessionidTokenTokenobj.get(sessionId).remove(token);
+            if (t != null) {
+                return t;
+            } else {
+                throw new OpenViduException(OpenViduException.Code.TOKEN_CANNOT_BE_CREATED_ERROR_CODE, sessionId);
+            }
+        } else {
+            throw new OpenViduException(OpenViduException.Code.ROOM_NOT_FOUND_ERROR_CODE, sessionId);
+        }
+    }
+
+    public void emptyCollections(Session session) {
+        sessions.remove(session.getSessionId());
+
+        sessionProperties.remove(session.getSessionId());
+        sessionidParticipantpublicidParticipant.remove(session.getSessionId());
+        sessionidTokenTokenobj.remove(session.getSessionId());
+
+        log.warn("Session '{}' removed and closed", session.getSessionId());
+    }
+
+    public void showTokens() {  log.info("<SESSIONID, TOKENS>: {}", this.sessionidTokenTokenobj.toString()); }
+
+    public void showInsecureParticipants() {
+        log.info("<INSECURE_PARTICIPANTS>: {}", this.insecureUsers.toString());
+    }
+
+    public void showAllParticipants() {
+        log.info("<SESSIONID, PARTICIPANTS>: {}", this.sessionidParticipantpublicidParticipant.toString());
+    }
+}

--- a/openvidu-server/src/main/java/io/openvidu/server/core/SessionStorage.java
+++ b/openvidu-server/src/main/java/io/openvidu/server/core/SessionStorage.java
@@ -63,6 +63,10 @@ public class SessionStorage {
 
     public SessionProperties getSessionProperties(String sessionId) { return this.sessionProperties.get(sessionId); }
 
+    public SessionProperties putSessionPropertiesIfAbsent(String sessionId, SessionProperties sessionProperties) {
+        return this.sessionProperties.putIfAbsent(sessionId, sessionProperties);
+    }
+
     /**
      * Returns all the participants inside a session.
      *

--- a/openvidu-server/src/main/java/io/openvidu/server/core/SessionStorage.java
+++ b/openvidu-server/src/main/java/io/openvidu/server/core/SessionStorage.java
@@ -308,4 +308,16 @@ public class SessionStorage {
     public void showAllParticipants() {
         log.info("<SESSIONID, PARTICIPANTS>: {}", this.sessionidParticipantpublicidParticipant.toString());
     }
+
+    public boolean isModeratorInSession(String sessionId, Participant participant) {
+        if (!this.isInsecureParticipant(participant.getParticipantPrivateId())) {
+            if (this.sessionidParticipantpublicidParticipant.get(sessionId) != null) {
+                return ParticipantRole.MODERATOR.equals(participant.getToken().getRole());
+            } else {
+                return false;
+            }
+        } else {
+            return true;
+        }
+    }
 }

--- a/openvidu-server/src/main/java/io/openvidu/server/core/Utils.java
+++ b/openvidu-server/src/main/java/io/openvidu/server/core/Utils.java
@@ -1,0 +1,24 @@
+package io.openvidu.server.core;
+
+import org.apache.commons.lang3.RandomStringUtils;
+
+public class Utils {
+
+    /**
+     * Generate a random alpha numeric key chain
+     * @return
+     */
+    public String generateRandomChain() {
+        return RandomStringUtils.randomAlphanumeric(16).toLowerCase();
+    }
+
+    /**
+     * Check that the metadata only has a max length of 10000 chars.
+     *
+     * @param metadata
+     * @return
+     */
+    public boolean isMetadataFormatCorrect(String metadata) {
+        return (metadata.length() <= 10000);
+    }
+}

--- a/openvidu-server/src/main/java/io/openvidu/server/kurento/core/KurentoSessionManager.java
+++ b/openvidu-server/src/main/java/io/openvidu/server/kurento/core/KurentoSessionManager.java
@@ -70,10 +70,10 @@ public class KurentoSessionManager extends SessionManager {
 
 			KurentoClientSessionInfo kcSessionInfo = new OpenViduKurentoClientSessionInfo(
 					participant.getParticipantPrivateId(), sessionId);
-			KurentoSession session = (KurentoSession) sessions.get(sessionId);
+			KurentoSession session = (KurentoSession) this.sessionStorage.getSession(sessionId);
 
 			if (session == null && kcSessionInfo != null) {
-				SessionProperties properties = sessionProperties.get(sessionId);
+				SessionProperties properties = this.sessionStorage.getSessionProperties(sessionId);
 				if (properties == null && this.isInsecureParticipant(participant.getParticipantPrivateId())) {
 					properties = new SessionProperties.Builder().mediaMode(MediaMode.ROUTED)
 							.recordingMode(RecordingMode.ALWAYS).defaultRecordingLayout(RecordingLayout.BEST_FIT)
@@ -81,7 +81,7 @@ public class KurentoSessionManager extends SessionManager {
 				}
 				createSession(kcSessionInfo, properties);
 			}
-			session = (KurentoSession) sessions.get(sessionId);
+			session = (KurentoSession) this.sessionStorage.getSession(sessionId);
 			if (session == null) {
 				log.warn("Session '{}' not found");
 				throw new OpenViduException(Code.ROOM_NOT_FOUND_ERROR_CODE, "Session '" + sessionId
@@ -125,26 +125,26 @@ public class KurentoSessionManager extends SessionManager {
 
 		// Update control data structures
 
-		if (sessionidParticipantpublicidParticipant.get(sessionId) != null) {
-			Participant p = sessionidParticipantpublicidParticipant.get(sessionId)
+		if (this.sessionStorage.getPublicIdParticipantMap(sessionId) != null) {
+			Participant p = this.sessionStorage.getPublicIdParticipantMap(sessionId)
 					.remove(participant.getParticipantPublicId());
 
 			if (this.coturnCredentialsService.isCoturnAvailable()) {
 				this.coturnCredentialsService.deleteUser(p.getToken().getTurnCredentials().getUsername());
 			}
 
-			if (sessionidTokenTokenobj.get(sessionId) != null) {
-				sessionidTokenTokenobj.get(sessionId).remove(p.getToken().getToken());
+			if (this.sessionStorage.getTokenObject(sessionId) != null) {
+				this.sessionStorage.getTokenObject(sessionId).remove(p.getToken().getToken());
 			}
 			boolean stillParticipant = false;
-			for (Session s : sessions.values()) {
+			for (Session s : this.sessionStorage.getSessionObjects()) {
 				if (s.getParticipantByPrivateId(p.getParticipantPrivateId()) != null) {
 					stillParticipant = true;
 					break;
 				}
 			}
 			if (!stillParticipant) {
-				insecureUsers.remove(p.getParticipantPrivateId());
+				this.sessionStorage.removeInsecureParticipant(p.getParticipantPrivateId());
 			}
 		}
 
@@ -437,7 +437,7 @@ public class KurentoSessionManager extends SessionManager {
 	public void createSession(KurentoClientSessionInfo kcSessionInfo, SessionProperties sessionProperties)
 			throws OpenViduException {
 		String sessionId = kcSessionInfo.getRoomName();
-		KurentoSession session = (KurentoSession) sessions.get(sessionId);
+		KurentoSession session = (KurentoSession) this.sessionStorage.getSession(sessionId);
 		if (session != null) {
 			throw new OpenViduException(Code.ROOM_CANNOT_BE_CREATED_ERROR_CODE,
 					"Session '" + sessionId + "' already exists");
@@ -446,7 +446,7 @@ public class KurentoSessionManager extends SessionManager {
 		session = new KurentoSession(sessionId, sessionProperties, kurentoClient, kurentoSessionEventsHandler,
 				kcProvider.destroyWhenUnused(), this.CDR, this.openviduConfig);
 
-		KurentoSession oldSession = (KurentoSession) sessions.putIfAbsent(sessionId, session);
+		KurentoSession oldSession = (KurentoSession) this.sessionStorage.putSessionIfAbsent(sessionId, session);
 		if (oldSession != null) {
 			log.warn("Session '{}' has just been created by another thread", sessionId);
 			return;

--- a/openvidu-server/src/main/java/io/openvidu/server/kurento/core/KurentoSessionManager.java
+++ b/openvidu-server/src/main/java/io/openvidu/server/kurento/core/KurentoSessionManager.java
@@ -447,6 +447,7 @@ public class KurentoSessionManager extends SessionManager {
 				kcProvider.destroyWhenUnused(), this.CDR, this.openviduConfig);
 
 		KurentoSession oldSession = (KurentoSession) this.sessionStorage.putSessionIfAbsent(sessionId, session);
+		this.sessionStorage.putSessionPropertiesIfAbsent(sessionId, sessionProperties);
 		if (oldSession != null) {
 			log.warn("Session '{}' has just been created by another thread", sessionId);
 			return;

--- a/openvidu-server/src/main/java/io/openvidu/server/rest/SessionRestController.java
+++ b/openvidu-server/src/main/java/io/openvidu/server/rest/SessionRestController.java
@@ -22,6 +22,7 @@ import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.concurrent.ConcurrentHashMap;
 
+import io.openvidu.server.core.*;
 import org.json.simple.JSONArray;
 import org.json.simple.JSONObject;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -43,10 +44,6 @@ import io.openvidu.java.client.RecordingMode;
 import io.openvidu.java.client.RecordingProperties;
 import io.openvidu.java.client.SessionProperties;
 import io.openvidu.server.config.OpenviduConfig;
-import io.openvidu.server.core.Participant;
-import io.openvidu.server.core.ParticipantRole;
-import io.openvidu.server.core.Session;
-import io.openvidu.server.core.SessionManager;
 import io.openvidu.server.recording.ComposedRecordingService;
 import io.openvidu.server.recording.Recording;
 
@@ -61,6 +58,9 @@ public class SessionRestController {
 
 	@Autowired
 	private SessionManager sessionManager;
+
+	@Autowired
+	private SessionStorage sessionStorage;
 
 	@Autowired
 	private ComposedRecordingService recordingService;
@@ -120,13 +120,13 @@ public class SessionRestController {
 
 		String sessionId;
 		if (customSessionId != null && !customSessionId.isEmpty()) {
-			if (sessionManager.sessionidTokenTokenobj.putIfAbsent(customSessionId, new ConcurrentHashMap<>()) != null) {
+			if (this.sessionStorage.putTokenObject(customSessionId, new ConcurrentHashMap<>()) != null) {
 				return new ResponseEntity<>(HttpStatus.CONFLICT);
 			}
 			sessionId = customSessionId;
 		} else {
 			sessionId = sessionManager.generateRandomChain();
-			sessionManager.sessionidTokenTokenobj.putIfAbsent(sessionId, new ConcurrentHashMap<>());
+			this.sessionStorage.putTokenObject(sessionId, new ConcurrentHashMap<>());
 		}
 
 		sessionManager.storeSessionId(sessionId, sessionProperties);


### PR DESCRIPTION
Hi!

While working on my Master thesis, i analysed Kurento Media Server and the OpenVidu implementation and got in contact with the `MediaMode.Relayed` Option.

I have read #37 and noticed, that this feature does not have a high priority.
For my project it is required to also support a direct connection between peers, so i started to implement this feature on my own.

After digging into the code i found out, that there are some general components like `RpcHandler` and `SessionRestController` which are currently tightly coupled with the KurentoSessionManager, because it is the only explicit implementation of a SessionManager.

So first of all i tried to decouble the KurentoSessionManger, so that it will be possible to inject another Manager based on the MediaMode used in a session.

In my approach it was necessary to change some elementary code base and i would like to know if these changes would be conform with your internal roadmap.

I would love to see this changes getting into the core (maybe with some adjustments). Nevertheless i will continue implementing the `MediaMode.Relayed` for at least my own project.
