### PR TITLE
openvidu-browser: fix double consent if initPublisher gets track as source

### DIFF
--- a/openvidu-browser/src/OpenVidu/Publisher.ts
+++ b/openvidu-browser/src/OpenVidu/Publisher.ts
@@ -374,6 +374,29 @@ export class Publisher extends StreamManager {
                 resolve();
             };
 
+            // Check if new constraints need to be generated
+            // No constraints needed if...
+            // - video track is given and no audio
+            // - audio track is given and no video
+            // - both video and audio tracks are given
+            if ((this.openvidu.isMediaStreamTrack(this.properties.videoSource) && !this.properties.audioSource)
+                || (!this.properties.videoSource && this.openvidu.isMediaStreamTrack(this.properties.audioSource))
+                || (this.openvidu.isMediaStreamTrack(this.properties.videoSource) && this.openvidu.isMediaStreamTrack(this.properties.audioSource))) {
+                var mediaStream = new MediaStream;
+                
+                if (this.openvidu.isMediaStreamTrack(this.properties.videoSource)) 
+                    mediaStream.addTrack((<MediaStreamTrack>this.properties.videoSource));
+
+                    if (this.openvidu.isMediaStreamTrack(this.properties.audioSource)) 
+                    mediaStream.addTrack((<MediaStreamTrack>this.properties.audioSource));
+                
+                // MediaStreamTracks are handled within callback - just call callback with new MediaStream() and let it 
+                // handle the sources
+
+                successCallback(mediaStream);
+            }
+
+
             this.openvidu.generateMediaConstraints(this.properties)
                 .then(constraints => {
 

--- a/openvidu-browser/src/OpenVidu/Publisher.ts
+++ b/openvidu-browser/src/OpenVidu/Publisher.ts
@@ -392,8 +392,10 @@ export class Publisher extends StreamManager {
                 
                 // MediaStreamTracks are handled within callback - just call callback with new MediaStream() and let it 
                 // handle the sources
-
                 successCallback(mediaStream);
+
+                // Return as we do not need to process further
+                return;
             }
 
 


### PR DESCRIPTION
if there is already a MediaStream created with OpenVidu.getUserMedia and no additional new stream, there is no need to generate new MediaConstraints (in Firefox, you would be requested to give access to your webcam while already streaming the screen)