### PR TITLE
Detect device in use

### DIFF
--- a/openvidu-browser/src/OpenVidu/OpenVidu.ts
+++ b/openvidu-browser/src/OpenVidu/OpenVidu.ts
@@ -237,7 +237,7 @@ export class OpenVidu {
         if (completionHandler !== undefined) {
           completionHandler(error);
         }
-        publisher.emitEvent('accessDenied', []);
+        publisher.emitEvent('accessDenied', [error]);
       });
 
     this.publishers.push(publisher);

--- a/openvidu-browser/src/OpenVidu/Publisher.ts
+++ b/openvidu-browser/src/OpenVidu/Publisher.ts
@@ -571,6 +571,21 @@ export class Publisher extends StreamManager {
                                                 errorCallback(new OpenViduError(errorName, errorMessage));
                                             });
                                         break;
+                                    case 'aborterror':
+                                        errorName = OpenViduErrorName.DEVICE_ALREADY_IN_USE;
+                                        errorMessage = error.toString();
+                                        errorCallback(new OpenViduError(errorName, errorMessage));
+                                        break;
+                                    case 'notreadableerror':
+                                        errorName = OpenViduErrorName.DEVICE_ALREADY_IN_USE;
+                                        errorMessage = error.toString();
+                                        errorCallback(new OpenViduError(errorName, errorMessage));
+                                        break;
+                                    default:
+                                        errorName = OpenViduErrorName.GENERIC_ERROR;
+                                        errorMessage = error.toString();
+                                        errorCallback(new OpenViduError(errorName, errorMessage));
+                                        break;
                                 }
                             });
                     } else {

--- a/openvidu-browser/src/OpenViduInternal/Enums/OpenViduError.ts
+++ b/openvidu-browser/src/OpenViduInternal/Enums/OpenViduError.ts
@@ -33,6 +33,12 @@ export enum OpenViduErrorName {
     DEVICE_ACCESS_DENIED = 'DEVICE_ACCESS_DENIED',
 
     /**
+     * The required input device is used by other software or browser when the browser asked for them.
+     * Returned upon unsuccessful [[OpenVidu.initPublisher]] or [[OpenVidu.getUserMedia]]
+     */
+    DEVICE_ALREADY_IN_USE = "DEVICE_ALREADY_IN_USE",
+
+    /**
      * The user hasn't granted permissions to capture some desktop screen when the browser asked for them.
      * Returned upon unsuccessful [[OpenVidu.initPublisher]] or [[OpenVidu.getUserMedia]]
      */


### PR DESCRIPTION
Hi!,

working on my project I have noticed that there is a case of error in the promise of getusermedia that is not being taken into account and therefore not sent as an error.

The changes made consist of:

1. I add 2 new cases in case of error in the promise of the getusermedia and the default with generic error.
aborterror -> is given in the Firefox browser when the cam you intend to use is already in use in another program or browser
notreadableerror -> same previous case but in Chrome
2. For the two previous cases I create a new type of error.
3. I add the "error" in the sending of the "accessDenied" event so that the client receives it and has more information.