### PR TITLE
Added reject with new Error if OpenVidu fetch fails

### DIFF
--- a/openvidu-node-client/src/OpenVidu.ts
+++ b/openvidu-node-client/src/OpenVidu.ts
@@ -483,9 +483,11 @@ export class OpenVidu {
             // `error.request` is an instance of XMLHttpRequest in the browser and an instance of
             // http.ClientRequest in node.js
             console.error(error.request);
+            reject(new Error(error.request));
           } else {
             // Something happened in setting up the request that triggered an Error
             console.error('Error', error.message);
+            reject(new Error(error.message));
           }
         });
     });


### PR DESCRIPTION
Added reject with new Error if OpenVidu fetch fails because of network problems.

I'm not sure why these two errors don't reject the Promise. 

But this addition will let me handle the error myself and reset the local mapSession and mapSessionToken, as well as determine the server is up/down. 