### PR TITLE
Make hostname non-static

### DIFF
--- a/openvidu-node-client/src/OpenVidu.ts
+++ b/openvidu-node-client/src/OpenVidu.ts
@@ -37,7 +37,7 @@ export class OpenVidu {
   /**
    * @hidden
    */
-  static hostname: string;
+  private hostname: string;
   /**
    * @hidden
    */
@@ -104,7 +104,7 @@ export class OpenVidu {
    */
   public createSession(properties?: SessionProperties): Promise<Session> {
     return new Promise<Session>((resolve, reject) => {
-      const session = new Session(properties);
+      const session = new Session(this.hostname, properties);
       session.getSessionIdHttp()
         .then(sessionId => {
           this.activeSessions.push(session);
@@ -174,7 +174,7 @@ export class OpenVidu {
       }
 
       axios.post(
-        'https://' + OpenVidu.hostname + ':' + OpenVidu.port + OpenVidu.API_RECORDINGS + OpenVidu.API_RECORDINGS_START,
+        'https://' + this.hostname + ':' + OpenVidu.port + OpenVidu.API_RECORDINGS + OpenVidu.API_RECORDINGS_START,
         data,
         {
           headers: {
@@ -228,7 +228,7 @@ export class OpenVidu {
     return new Promise<Recording>((resolve, reject) => {
 
       axios.post(
-        'https://' + OpenVidu.hostname + ':' + OpenVidu.port + OpenVidu.API_RECORDINGS + OpenVidu.API_RECORDINGS_STOP + '/' + recordingId,
+        'https://' + this.hostname + ':' + OpenVidu.port + OpenVidu.API_RECORDINGS + OpenVidu.API_RECORDINGS_STOP + '/' + recordingId,
         undefined,
         {
           headers: {
@@ -280,7 +280,7 @@ export class OpenVidu {
     return new Promise<Recording>((resolve, reject) => {
 
       axios.get(
-        'https://' + OpenVidu.hostname + ':' + OpenVidu.port + OpenVidu.API_RECORDINGS + '/' + recordingId,
+        'https://' + this.hostname + ':' + OpenVidu.port + OpenVidu.API_RECORDINGS + '/' + recordingId,
         {
           headers: {
             'Authorization': OpenVidu.basicAuth,
@@ -322,7 +322,7 @@ export class OpenVidu {
     return new Promise<Recording[]>((resolve, reject) => {
 
       axios.get(
-        'https://' + OpenVidu.hostname + ':' + OpenVidu.port + OpenVidu.API_RECORDINGS,
+        'https://' + this.hostname + ':' + OpenVidu.port + OpenVidu.API_RECORDINGS,
         {
           headers: {
             Authorization: OpenVidu.basicAuth
@@ -374,7 +374,7 @@ export class OpenVidu {
     return new Promise<Error>((resolve, reject) => {
 
       axios.delete(
-        'https://' + OpenVidu.hostname + ':' + OpenVidu.port + OpenVidu.API_RECORDINGS + '/' + recordingId,
+        'https://' + this.hostname + ':' + OpenVidu.port + OpenVidu.API_RECORDINGS + '/' + recordingId,
         {
           headers: {
             'Authorization': OpenVidu.basicAuth,
@@ -417,7 +417,7 @@ export class OpenVidu {
   public fetch(): Promise<boolean> {
     return new Promise<boolean>((resolve, reject) => {
       axios.get(
-        'https://' + OpenVidu.hostname + ':' + OpenVidu.port + OpenVidu.API_SESSIONS,
+        'https://' + this.hostname + ':' + OpenVidu.port + OpenVidu.API_SESSIONS,
         {
           headers: {
             Authorization: OpenVidu.basicAuth
@@ -444,7 +444,7 @@ export class OpenVidu {
                 }
               });
               if (!!storedSession) {
-                const fetchedSession: Session = new Session().resetSessionWithJson(session);
+                const fetchedSession: Session = new Session(this.hostname).resetSessionWithJson(session);
                 const changed: boolean = !storedSession.equalTo(fetchedSession);
                 if (changed) {
                   storedSession = fetchedSession;
@@ -587,7 +587,7 @@ export class OpenVidu {
 
     return new Promise<{ changes: boolean, sessionChanges: ObjMap<boolean> }>((resolve, reject) => {
       axios.get(
-        'https://' + OpenVidu.hostname + ':' + OpenVidu.port + OpenVidu.API_SESSIONS + '?webRtcStats=true',
+        'https://' + this.hostname + ':' + OpenVidu.port + OpenVidu.API_SESSIONS + '?webRtcStats=true',
         {
           headers: {
             Authorization: OpenVidu.basicAuth
@@ -616,7 +616,7 @@ export class OpenVidu {
                 }
               });
               if (!!storedSession) {
-                const fetchedSession: Session = new Session().resetSessionWithJson(session);
+                const fetchedSession: Session = new Session(this.hostname).resetSessionWithJson(session);
                 fetchedSession.activeConnections.forEach(connection => {
                   addWebRtcStatsToConnections(connection, session.connections.content);
                 });
@@ -690,10 +690,10 @@ export class OpenVidu {
   private setHostnameAndPort(): void {
     const urlSplitted = this.urlOpenViduServer.split(':');
     if (urlSplitted.length === 3) { // URL has format: http:// + hostname + :port
-      OpenVidu.hostname = this.urlOpenViduServer.split(':')[1].replace(/\//g, '');
+      this.hostname = this.urlOpenViduServer.split(':')[1].replace(/\//g, '');
       OpenVidu.port = parseInt(this.urlOpenViduServer.split(':')[2].replace(/\//g, ''));
     } else if (urlSplitted.length === 2) { // URL has format: hostname + :port
-      OpenVidu.hostname = this.urlOpenViduServer.split(':')[0].replace(/\//g, '');
+      this.hostname = this.urlOpenViduServer.split(':')[0].replace(/\//g, '');
       OpenVidu.port = parseInt(this.urlOpenViduServer.split(':')[1].replace(/\//g, ''));
     } else {
       console.error("URL format incorrect: it must contain hostname and port (current value: '" + this.urlOpenViduServer + "')");

--- a/openvidu-node-client/src/Session.ts
+++ b/openvidu-node-client/src/Session.ts
@@ -65,7 +65,7 @@ export class Session {
     /**
      * @hidden
      */
-    constructor(propertiesOrJson?) {
+    constructor(private hostname: string, propertiesOrJson?) {
         if (!!propertiesOrJson) {
             // Defined parameter
             if (!!propertiesOrJson.sessionId) {
@@ -108,7 +108,7 @@ export class Session {
             });
 
             axios.post(
-                'https://' + OpenVidu.hostname + ':' + OpenVidu.port + OpenVidu.API_TOKENS,
+                'https://' + this.hostname + ':' + OpenVidu.port + OpenVidu.API_TOKENS,
                 data,
                 {
                     headers: {
@@ -152,7 +152,7 @@ export class Session {
     public close(): Promise<any> {
         return new Promise<any>((resolve, reject) => {
             axios.delete(
-                'https://' + OpenVidu.hostname + ':' + OpenVidu.port + OpenVidu.API_SESSIONS + '/' + this.sessionId,
+                'https://' + this.hostname + ':' + OpenVidu.port + OpenVidu.API_SESSIONS + '/' + this.sessionId,
                 {
                     headers: {
                         'Authorization': OpenVidu.basicAuth,
@@ -202,7 +202,7 @@ export class Session {
         return new Promise<boolean>((resolve, reject) => {
             const beforeJSON: string = JSON.stringify(this);
             axios.get(
-                'https://' + OpenVidu.hostname + ':' + OpenVidu.port + OpenVidu.API_SESSIONS + '/' + this.sessionId,
+                'https://' + this.hostname + ':' + OpenVidu.port + OpenVidu.API_SESSIONS + '/' + this.sessionId,
                 {
                     headers: {
                         'Authorization': OpenVidu.basicAuth,
@@ -254,7 +254,7 @@ export class Session {
         return new Promise<any>((resolve, reject) => {
             const connectionId: string = typeof connection === 'string' ? connection : (<Connection>connection).connectionId;
             axios.delete(
-                'https://' + OpenVidu.hostname + ':' + OpenVidu.port + OpenVidu.API_SESSIONS + '/' + this.sessionId + '/connection/' + connectionId,
+                'https://' + this.hostname + ':' + OpenVidu.port + OpenVidu.API_SESSIONS + '/' + this.sessionId + '/connection/' + connectionId,
                 {
                     headers: {
                         'Authorization': OpenVidu.basicAuth,
@@ -333,7 +333,7 @@ export class Session {
         return new Promise<any>((resolve, reject) => {
             const streamId: string = typeof publisher === 'string' ? publisher : (<Publisher>publisher).streamId;
             axios.delete(
-                'https://' + OpenVidu.hostname + ':' + OpenVidu.port + OpenVidu.API_SESSIONS + '/' + this.sessionId + '/stream/' + streamId,
+                'https://' + this.hostname + ':' + OpenVidu.port + OpenVidu.API_SESSIONS + '/' + this.sessionId + '/stream/' + streamId,
                 {
                     headers: {
                         'Authorization': OpenVidu.basicAuth,
@@ -405,7 +405,7 @@ export class Session {
             });
 
             axios.post(
-                'https://' + OpenVidu.hostname + ':' + OpenVidu.port + OpenVidu.API_SESSIONS,
+                'https://' + this.hostname + ':' + OpenVidu.port + OpenVidu.API_SESSIONS,
                 data,
                 {
                     headers: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,3 @@
+{
+  "lockfileVersion": 1
+}


### PR DESCRIPTION
This addresses Issue 256.

I deployed more than one servers to find that the host name is used as static globally. So I modified this value to be non-static, so that managing more than one server became possible.