### PR TITLE
remove static getActiveSessions method

### DIFF
--- a/openvidu-node-client/src/OpenVidu.ts
+++ b/openvidu-node-client/src/OpenVidu.ts
@@ -37,15 +37,15 @@ export class OpenVidu {
   /**
    * @hidden
    */
-  private hostname: string;
+  public hostname: string;
   /**
    * @hidden
    */
-  static port: number;
+  public port: number;
   /**
    * @hidden
    */
-  static basicAuth: string;
+  public basicAuth: string;
 
   /**
    * @hidden
@@ -67,8 +67,6 @@ export class OpenVidu {
    * @hidden
    */
   static readonly API_TOKENS = '/api/tokens';
-
-  private static o: OpenVidu;
 
 
   /**
@@ -93,8 +91,7 @@ export class OpenVidu {
    */
   constructor(private urlOpenViduServer: string, secret: string) {
     this.setHostnameAndPort();
-    OpenVidu.basicAuth = this.getBasicAuth(secret);
-    OpenVidu.o = this;
+    this.basicAuth = this.getBasicAuth(secret);
   }
 
   /**
@@ -104,7 +101,7 @@ export class OpenVidu {
    */
   public createSession(properties?: SessionProperties): Promise<Session> {
     return new Promise<Session>((resolve, reject) => {
-      const session = new Session(this.hostname, properties);
+      const session = new Session(this, properties);
       session.getSessionIdHttp()
         .then(sessionId => {
           this.activeSessions.push(session);
@@ -174,11 +171,11 @@ export class OpenVidu {
       }
 
       axios.post(
-        'https://' + this.hostname + ':' + OpenVidu.port + OpenVidu.API_RECORDINGS + OpenVidu.API_RECORDINGS_START,
+        'https://' + this.hostname + ':' + this.port + OpenVidu.API_RECORDINGS + OpenVidu.API_RECORDINGS_START,
         data,
         {
           headers: {
-            'Authorization': OpenVidu.basicAuth,
+            'Authorization': this.basicAuth,
             'Content-Type': 'application/json'
           }
         }
@@ -228,11 +225,11 @@ export class OpenVidu {
     return new Promise<Recording>((resolve, reject) => {
 
       axios.post(
-        'https://' + this.hostname + ':' + OpenVidu.port + OpenVidu.API_RECORDINGS + OpenVidu.API_RECORDINGS_STOP + '/' + recordingId,
+        'https://' + this.hostname + ':' + this.port + OpenVidu.API_RECORDINGS + OpenVidu.API_RECORDINGS_STOP + '/' + recordingId,
         undefined,
         {
           headers: {
-            'Authorization': OpenVidu.basicAuth,
+            'Authorization': this.basicAuth,
             'Content-Type': 'application/x-www-form-urlencoded'
           }
         }
@@ -280,10 +277,10 @@ export class OpenVidu {
     return new Promise<Recording>((resolve, reject) => {
 
       axios.get(
-        'https://' + this.hostname + ':' + OpenVidu.port + OpenVidu.API_RECORDINGS + '/' + recordingId,
+        'https://' + this.hostname + ':' + this.port + OpenVidu.API_RECORDINGS + '/' + recordingId,
         {
           headers: {
-            'Authorization': OpenVidu.basicAuth,
+            'Authorization': this.basicAuth,
             'Content-Type': 'application/x-www-form-urlencoded'
           }
         }
@@ -322,10 +319,10 @@ export class OpenVidu {
     return new Promise<Recording[]>((resolve, reject) => {
 
       axios.get(
-        'https://' + this.hostname + ':' + OpenVidu.port + OpenVidu.API_RECORDINGS,
+        'https://' + this.hostname + ':' + this.port + OpenVidu.API_RECORDINGS,
         {
           headers: {
-            Authorization: OpenVidu.basicAuth
+            Authorization: this.basicAuth
           }
         }
       )
@@ -374,10 +371,10 @@ export class OpenVidu {
     return new Promise<Error>((resolve, reject) => {
 
       axios.delete(
-        'https://' + this.hostname + ':' + OpenVidu.port + OpenVidu.API_RECORDINGS + '/' + recordingId,
+        'https://' + this.hostname + ':' + this.port + OpenVidu.API_RECORDINGS + '/' + recordingId,
         {
           headers: {
-            'Authorization': OpenVidu.basicAuth,
+            'Authorization': this.basicAuth,
             'Content-Type': 'application/x-www-form-urlencoded'
           }
         }
@@ -417,10 +414,10 @@ export class OpenVidu {
   public fetch(): Promise<boolean> {
     return new Promise<boolean>((resolve, reject) => {
       axios.get(
-        'https://' + this.hostname + ':' + OpenVidu.port + OpenVidu.API_SESSIONS,
+        'https://' + this.hostname + ':' + this.port + OpenVidu.API_SESSIONS,
         {
           headers: {
-            Authorization: OpenVidu.basicAuth
+            Authorization: this.basicAuth
           }
         }
       )
@@ -444,7 +441,7 @@ export class OpenVidu {
                 }
               });
               if (!!storedSession) {
-                const fetchedSession: Session = new Session(this.hostname).resetSessionWithJson(session);
+                const fetchedSession: Session = new Session(this).resetSessionWithJson(session);
                 const changed: boolean = !storedSession.equalTo(fetchedSession);
                 if (changed) {
                   storedSession = fetchedSession;
@@ -453,7 +450,7 @@ export class OpenVidu {
                 console.log("Available session '" + storedSession.sessionId + "' info fetched. Any change: " + changed);
                 hasChanged = hasChanged || changed;
               } else {
-                this.activeSessions.push(new Session(this.hostname, session));
+                this.activeSessions.push(new Session(this, session));
                 console.log("New session '" + session.sessionId + "' info fetched");
                 hasChanged = true;
               }
@@ -587,10 +584,10 @@ export class OpenVidu {
 
     return new Promise<{ changes: boolean, sessionChanges: ObjMap<boolean> }>((resolve, reject) => {
       axios.get(
-        'https://' + this.hostname + ':' + OpenVidu.port + OpenVidu.API_SESSIONS + '?webRtcStats=true',
+        'https://' + this.hostname + ':' + this.port + OpenVidu.API_SESSIONS + '?webRtcStats=true',
         {
           headers: {
-            Authorization: OpenVidu.basicAuth
+            Authorization: this.basicAuth
           }
         }
       )
@@ -616,7 +613,7 @@ export class OpenVidu {
                 }
               });
               if (!!storedSession) {
-                const fetchedSession: Session = new Session(this.hostname).resetSessionWithJson(session);
+                const fetchedSession: Session = new Session(this).resetSessionWithJson(session);
                 fetchedSession.activeConnections.forEach(connection => {
                   addWebRtcStatsToConnections(connection, session.connections.content);
                 });
@@ -638,7 +635,7 @@ export class OpenVidu {
                 sessionChanges[storedSession.sessionId] = changed;
                 globalChanges = globalChanges || changed;
               } else {
-                const newSession = new Session(this.hostname, session);
+                const newSession = new Session(this, session);
                 newSession.activeConnections.forEach(connection => {
                   addWebRtcStatsToConnections(connection, session.connections.content);
                 });
@@ -691,20 +688,13 @@ export class OpenVidu {
     const urlSplitted = this.urlOpenViduServer.split(':');
     if (urlSplitted.length === 3) { // URL has format: http:// + hostname + :port
       this.hostname = this.urlOpenViduServer.split(':')[1].replace(/\//g, '');
-      OpenVidu.port = parseInt(this.urlOpenViduServer.split(':')[2].replace(/\//g, ''));
+      this.port = parseInt(this.urlOpenViduServer.split(':')[2].replace(/\//g, ''));
     } else if (urlSplitted.length === 2) { // URL has format: hostname + :port
       this.hostname = this.urlOpenViduServer.split(':')[0].replace(/\//g, '');
-      OpenVidu.port = parseInt(this.urlOpenViduServer.split(':')[1].replace(/\//g, ''));
+      this.port = parseInt(this.urlOpenViduServer.split(':')[1].replace(/\//g, ''));
     } else {
       console.error("URL format incorrect: it must contain hostname and port (current value: '" + this.urlOpenViduServer + "')");
     }
-  }
-
-  /**
-   * @hidden
-   */
-  static getActiveSessions(): Session[] {
-    return this.o.activeSessions;
   }
 
 }

--- a/openvidu-node-client/src/Session.ts
+++ b/openvidu-node-client/src/Session.ts
@@ -66,7 +66,6 @@ export class Session {
      * @hidden
      */
     constructor(private ov: OpenVidu, propertiesOrJson?) {
-        console.log(ov)
         if (!!propertiesOrJson) {
             // Defined parameter
             if (!!propertiesOrJson.sessionId) {

--- a/openvidu-node-client/src/Session.ts
+++ b/openvidu-node-client/src/Session.ts
@@ -65,7 +65,8 @@ export class Session {
     /**
      * @hidden
      */
-    constructor(private hostname: string, propertiesOrJson?) {
+    constructor(private ov: OpenVidu, propertiesOrJson?) {
+        console.log(ov)
         if (!!propertiesOrJson) {
             // Defined parameter
             if (!!propertiesOrJson.sessionId) {
@@ -108,11 +109,11 @@ export class Session {
             });
 
             axios.post(
-                'https://' + this.hostname + ':' + OpenVidu.port + OpenVidu.API_TOKENS,
+                'https://' + this.ov.hostname + ':' + this.ov.port + OpenVidu.API_TOKENS,
                 data,
                 {
                     headers: {
-                        'Authorization': OpenVidu.basicAuth,
+                        'Authorization': this.ov.basicAuth,
                         'Content-Type': 'application/json'
                     }
                 }
@@ -152,10 +153,10 @@ export class Session {
     public close(): Promise<any> {
         return new Promise<any>((resolve, reject) => {
             axios.delete(
-                'https://' + this.hostname + ':' + OpenVidu.port + OpenVidu.API_SESSIONS + '/' + this.sessionId,
+                'https://' + this.ov.hostname + ':' + this.ov.port + OpenVidu.API_SESSIONS + '/' + this.sessionId,
                 {
                     headers: {
-                        'Authorization': OpenVidu.basicAuth,
+                        'Authorization': this.ov.basicAuth,
                         'Content-Type': 'application/x-www-form-urlencoded'
                     }
                 }
@@ -163,8 +164,8 @@ export class Session {
                 .then(res => {
                     if (res.status === 204) {
                         // SUCCESS response from openvidu-server
-                        const indexToRemove: number = OpenVidu.getActiveSessions().findIndex(s => s.sessionId === this.sessionId);
-                        OpenVidu.getActiveSessions().splice(indexToRemove, 1);
+                        const indexToRemove: number = this.ov.activeSessions.findIndex(s => s.sessionId === this.sessionId);
+                        this.ov.activeSessions.splice(indexToRemove, 1);
                         resolve();
                     } else {
                         // ERROR response from openvidu-server. Resolve HTTP status
@@ -202,10 +203,10 @@ export class Session {
         return new Promise<boolean>((resolve, reject) => {
             const beforeJSON: string = JSON.stringify(this);
             axios.get(
-                'https://' + this.hostname + ':' + OpenVidu.port + OpenVidu.API_SESSIONS + '/' + this.sessionId,
+                'https://' + this.ov.hostname + ':' + this.ov.port + OpenVidu.API_SESSIONS + '/' + this.sessionId,
                 {
                     headers: {
-                        'Authorization': OpenVidu.basicAuth,
+                        'Authorization': this.ov.basicAuth,
                         'Content-Type': 'application/x-www-form-urlencoded'
                     }
                 }
@@ -254,10 +255,10 @@ export class Session {
         return new Promise<any>((resolve, reject) => {
             const connectionId: string = typeof connection === 'string' ? connection : (<Connection>connection).connectionId;
             axios.delete(
-                'https://' + this.hostname + ':' + OpenVidu.port + OpenVidu.API_SESSIONS + '/' + this.sessionId + '/connection/' + connectionId,
+                'https://' + this.ov.hostname + ':' + this.ov.port + OpenVidu.API_SESSIONS + '/' + this.sessionId + '/connection/' + connectionId,
                 {
                     headers: {
-                        'Authorization': OpenVidu.basicAuth,
+                        'Authorization': this.ov.basicAuth,
                         'Content-Type': 'application/x-www-form-urlencoded'
                     }
                 })
@@ -333,10 +334,10 @@ export class Session {
         return new Promise<any>((resolve, reject) => {
             const streamId: string = typeof publisher === 'string' ? publisher : (<Publisher>publisher).streamId;
             axios.delete(
-                'https://' + this.hostname + ':' + OpenVidu.port + OpenVidu.API_SESSIONS + '/' + this.sessionId + '/stream/' + streamId,
+                'https://' + this.ov.hostname + ':' + this.ov.port + OpenVidu.API_SESSIONS + '/' + this.sessionId + '/stream/' + streamId,
                 {
                     headers: {
-                        'Authorization': OpenVidu.basicAuth,
+                        'Authorization': this.ov.basicAuth,
                         'Content-Type': 'application/x-www-form-urlencoded'
                     }
                 }
@@ -405,11 +406,11 @@ export class Session {
             });
 
             axios.post(
-                'https://' + this.hostname + ':' + OpenVidu.port + OpenVidu.API_SESSIONS,
+                'https://' + this.ov.hostname + ':' + this.ov.port + OpenVidu.API_SESSIONS,
                 data,
                 {
                     headers: {
-                        'Authorization': OpenVidu.basicAuth,
+                        'Authorization': this.ov.basicAuth,
                         'Content-Type': 'application/json'
                     }
                 }


### PR DESCRIPTION
The `static getActiveSessions()` method threw me off while running an array of `OpenVidu` objects.

I know developing a cluster is somewhere on the roadmap, but as of now the only way to run a cluster is to start multiple OpenVidu instances, which I did. While fetching active sessions, these sessions need to be attached to a specific instance of the class, instead of statically.