### PR TITLE
Fix to get webrtc stats in Firefox

### DIFF
--- a/openvidu-browser/src/OpenViduInternal/WebRtcStats/WebRtcStats.ts
+++ b/openvidu-browser/src/OpenViduInternal/WebRtcStats/WebRtcStats.ts
@@ -183,10 +183,7 @@ export class WebRtcStats {
                     if ((stat.type === 'inbound-rtp') &&
                         (
                             // Avoid firefox empty outbound-rtp statistics
-                            stat.nackCount !== null &&
-                            stat.isRemote === false &&
-                            stat.id.startsWith('inbound') &&
-                            stat.remoteId.startsWith('inbound')
+                            stat.nackCount !== null
                         )) {
 
                         const metricId = 'webrtc_inbound_' + stat.mediaType + '_' + stat.ssrc;
@@ -231,12 +228,7 @@ export class WebRtcStats {
 
                         sendPost(JSON.stringify(json));
 
-                    } else if ((stat.type === 'outbound-rtp') &&
-                        (
-                            // Avoid firefox empty inbound-rtp statistics
-                            stat.isRemote === false &&
-                            stat.id.toLowerCase().includes('outbound')
-                        )) {
+                    } else if (stat.type === 'outbound-rtp'){
 
                         const metricId = 'webrtc_outbound_' + stat.mediaType + '_' + stat.ssrc;
 


### PR DESCRIPTION
I've been testing for statistics and I've seen that when I use the Firefox browser, I wasn't getting anything.
After performing a code debug I have seen that some of the conditions that were used caused them not to be accessed:

stat.isRemote always reaches undefined
stat.id and stat.remoteId are alphanumeric values that never contain the required word inbound or outbound

Therefore, I have eliminated these conditions and thus be able to obtain statistical values with the Firefox browser