### PR TITLE
openvidu-server: add message sent event

### DIFF
--- a/openvidu-server/src/main/java/io/openvidu/server/cdr/CDREventName.java
+++ b/openvidu-server/src/main/java/io/openvidu/server/cdr/CDREventName.java
@@ -21,6 +21,6 @@ public enum CDREventName {
 
 	sessionCreated, sessionDestroyed, participantJoined, participantLeft, webrtcConnectionCreated,
 	webrtcConnectionDestroyed, recordingStarted, recordingStopped, recordingStatusChanged, filterEventDispatched,
-	mediaNodeStatusChanged, autoscaling
+	mediaNodeStatusChanged, autoscaling, messageSent
 
 }

--- a/openvidu-server/src/main/java/io/openvidu/server/cdr/CDREventSendMessage.java
+++ b/openvidu-server/src/main/java/io/openvidu/server/cdr/CDREventSendMessage.java
@@ -10,29 +10,18 @@ public class CDREventSendMessage extends CDREvent {
 	private Participant participant;
 	private JsonObject message;
 	
-	
-	
 	public CDREventSendMessage(Participant participant, JsonObject message, Long timeStamp) {
 		super(CDREventName.messageSent, participant.getSessionId() , timeStamp);
 		this.participant = participant;
 		this.message = message;
-		// TODO Auto-generated constructor stub
 	}
-
-
 
 	@Override
 	public JsonObject toJson() {
-		// TODO Auto-generated method stub
 		JsonObject json = super.toJson();
 		json.addProperty("participantId", this.participant.getParticipantPublicId());
 		json.addProperty("data", message.get("data").getAsString());
 		json.addProperty("type", message.get("type").getAsString());
 		return json;
 	}
-	
-	
-	
-	
-
 }

--- a/openvidu-server/src/main/java/io/openvidu/server/cdr/CDREventSendMessage.java
+++ b/openvidu-server/src/main/java/io/openvidu/server/cdr/CDREventSendMessage.java
@@ -1,0 +1,38 @@
+package io.openvidu.server.cdr;
+
+
+import com.google.gson.JsonObject;
+
+import io.openvidu.server.core.Participant;
+
+public class CDREventSendMessage extends CDREvent {
+
+	private Participant participant;
+	private JsonObject message;
+	
+	
+	
+	public CDREventSendMessage(Participant participant, JsonObject message, Long timeStamp) {
+		super(CDREventName.messageSent, participant.getSessionId() , timeStamp);
+		this.participant = participant;
+		this.message = message;
+		// TODO Auto-generated constructor stub
+	}
+
+
+
+	@Override
+	public JsonObject toJson() {
+		// TODO Auto-generated method stub
+		JsonObject json = super.toJson();
+		json.addProperty("participantId", this.participant.getParticipantPublicId());
+		json.addProperty("data", message.get("data").getAsString());
+		json.addProperty("type", message.get("type").getAsString());
+		return json;
+	}
+	
+	
+	
+	
+
+}

--- a/openvidu-server/src/main/java/io/openvidu/server/cdr/CallDetailRecord.java
+++ b/openvidu-server/src/main/java/io/openvidu/server/cdr/CallDetailRecord.java
@@ -29,6 +29,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 
+import com.google.gson.JsonObject;
+
 import io.openvidu.java.client.Recording.Status;
 import io.openvidu.server.core.EndReason;
 import io.openvidu.server.core.MediaOptions;
@@ -55,6 +57,7 @@ import io.openvidu.server.webhook.CDRLoggerWebhook;
  * - 'recordingStopped'				{sessionId, timestamp, id, name, hasAudio, hasVideo, resolution, recordingLayout, size}
  * - 'recordingStatusChanged'		{sessionId, timestamp, id, name, hasAudio, hasVideo, resolution, recordingLayout, size, status}
  * - 'filterEventDispatched'		{sessionId, timestamp, participantId, streamId, filterType, eventType, data}
+ * - 'sendMessage'                  {sessionId, timestamp, participantId, data, type}
  * 
  * PROPERTIES VALUES:
  * 
@@ -82,6 +85,8 @@ import io.openvidu.server.webhook.CDRLoggerWebhook;
  * - participantLeft.reason: 			"unsubscribe", "unpublish", "disconnect", "networkDisconnect", "mediaServerDisconnect", "openviduServerStopped"
  * - sessionDestroyed.reason: 			"lastParticipantLeft", "mediaServerDisconnect", "openviduServerStopped"
  * - recordingStopped.reason:			"recordingStoppedByServer", "lastParticipantLeft", "sessionClosedByServer", "automaticStop", "mediaServerDisconnect", "openviduServerStopped"
+ * - data: string
+ * - type: string
  * 
  * [OPTIONAL_PROPERTIES]:
  * - receivingFrom:		only if connection = "INBOUND"
@@ -221,6 +226,11 @@ public class CallDetailRecord {
 	public void recordRecordingStatusChanged(Recording recording, EndReason finalReason, long timestamp,
 			Status status) {
 		this.log(new CDREventRecordingStatus(recording, recording.getCreatedAt(), finalReason, timestamp, status));
+	}
+	
+	public void recordSendMessage(Participant participant, JsonObject message, Integer transactionId) {
+		CDREventSendMessage eventMessageSent = new CDREventSendMessage(participant, message, System.currentTimeMillis());
+		this.log(eventMessageSent);
 	}
 
 	public void recordFilterEventDispatched(String sessionId, String participantId, String streamId, String filterType,

--- a/openvidu-server/src/main/java/io/openvidu/server/core/SessionEventsHandler.java
+++ b/openvidu-server/src/main/java/io/openvidu/server/core/SessionEventsHandler.java
@@ -374,7 +374,6 @@ public class SessionEventsHandler {
 			CDR.recordSendMessage(participant, message, transactionId);
 			rpcNotificationService.sendResponse(participant.getParticipantPrivateId(), transactionId, new JsonObject());
 		}
-		
 	}
 
 	public void onStreamPropertyChanged(Participant participant, Integer transactionId, Set<Participant> participants,

--- a/openvidu-server/src/main/java/io/openvidu/server/core/SessionEventsHandler.java
+++ b/openvidu-server/src/main/java/io/openvidu/server/core/SessionEventsHandler.java
@@ -371,8 +371,10 @@ public class SessionEventsHandler {
 		}
 
 		if (isRpcCall) {
+			CDR.recordSendMessage(participant, message, transactionId);
 			rpcNotificationService.sendResponse(participant.getParticipantPrivateId(), transactionId, new JsonObject());
 		}
+		
 	}
 
 	public void onStreamPropertyChanged(Participant participant, Integer transactionId, Set<Participant> participants,


### PR DESCRIPTION
This patch registers the sendMessage event (signal: chat and signal: xxx) for tracking all the messages exchanged between the various clients.

As pointed out inside issues:
https://github.com/OpenVidu/openvidu/issues/288 and https://github.com/OpenVidu/openvidu/issues/399