### PR TITLE
Add NONE VideoInsertMode

### DIFF
--- a/openvidu-browser/src/OpenVidu/StreamManager.ts
+++ b/openvidu-browser/src/OpenVidu/StreamManager.ts
@@ -329,6 +329,8 @@ export class StreamManager implements EventDispatcher {
             case VideoInsertMode.REPLACE:
                 targEl.parentNode!!.replaceChild(video, targEl);
                 break;
+            case VideoInsertMode.NONE:
+                break;
             default:
                 insMode = VideoInsertMode.APPEND;
                 targEl.appendChild(video);

--- a/openvidu-browser/src/OpenViduInternal/Enums/VideoInsertMode.ts
+++ b/openvidu-browser/src/OpenViduInternal/Enums/VideoInsertMode.ts
@@ -39,6 +39,11 @@ export enum VideoInsertMode {
     /**
      * Video replaces target element
      */
-    REPLACE = 'REPLACE'
+    REPLACE = 'REPLACE',
+
+    /**
+     * Video is not inserted into the target element
+     */
+    NONE = 'NONE'
 
 }


### PR DESCRIPTION
In certain situations, e.g. not automatically displaying the local stream, for the desired insertMode to be NONE. 
Alternatively, one could not supply a valid targetElement, however an Error would be thrown.