### PR TITLE
openvidu-server: fix checkWebsocketUri condition

### DIFF
--- a/openvidu-server/src/main/java/io/openvidu/server/config/OpenviduConfig.java
+++ b/openvidu-server/src/main/java/io/openvidu/server/config/OpenviduConfig.java
@@ -381,7 +381,7 @@ public class OpenviduConfig {
 
 	public URI checkWebsocketUri(String uri) throws Exception {
 		try {
-			if (!uri.startsWith("ws://") || !uri.startsWith("wss://")) {
+			if (!uri.startsWith("ws://") && !uri.startsWith("wss://")) {
 				throw new Exception("WebSocket protocol not found");
 			}
 			String parsedUri = uri.replaceAll("^ws://", "http://").replaceAll("^wss://", "https://");

--- a/openvidu-server/src/main/java/io/openvidu/server/config/OpenviduConfig.java
+++ b/openvidu-server/src/main/java/io/openvidu/server/config/OpenviduConfig.java
@@ -381,7 +381,7 @@ public class OpenviduConfig {
 
 	public URI checkWebsocketUri(String uri) throws Exception {
 		try {
-			if (!uri.startsWith("ws://") || uri.startsWith("wss://")) {
+			if (!uri.startsWith("ws://") || !uri.startsWith("wss://")) {
 				throw new Exception("WebSocket protocol not found");
 			}
 			String parsedUri = uri.replaceAll("^ws://", "http://").replaceAll("^wss://", "https://");


### PR DESCRIPTION
This patch fixes condition in `checkWebsocketUri` when `WSS` protocol is always considered as non-WebSocket