### PR TITLE
Add generic OpenViduException

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,8 +4,10 @@
 
 /target
 .classpath
+.idea
 .project
 .settings
+*.iml
 *orig
 .springBeans
 *tmp/

--- a/openvidu-java-client/pom.xml
+++ b/openvidu-java-client/pom.xml
@@ -10,7 +10,7 @@
 	</parent>
 
 	<artifactId>openvidu-java-client</artifactId>
-	<version>2.12.1</version>
+	<version>2.13.0</version>
 	<packaging>jar</packaging>
 
 	<name>OpenVidu Java Client</name>

--- a/openvidu-java-client/pom.xml
+++ b/openvidu-java-client/pom.xml
@@ -10,7 +10,7 @@
 	</parent>
 
 	<artifactId>openvidu-java-client</artifactId>
-	<version>2.13.0</version>
+	<version>2.12.1</version>
 	<packaging>jar</packaging>
 
 	<name>OpenVidu Java Client</name>

--- a/openvidu-java-client/src/main/java/io/openvidu/java/client/OpenViduException.java
+++ b/openvidu-java-client/src/main/java/io/openvidu/java/client/OpenViduException.java
@@ -18,23 +18,16 @@
 package io.openvidu.java.client;
 
 /**
- * Defines error responses from OpenVidu Server
+ * Defines a generic OpenVidu exception
  */
-public class OpenViduHttpException extends OpenViduException {
+public class OpenViduException extends Exception {
 
-	private static final long serialVersionUID = 1L;
-	private int status;
-
-	protected OpenViduHttpException(int status) {
-		super(Integer.toString(status));
-		this.status = status;
+	protected OpenViduException(String message) {
+		super(message);
 	}
 
-	/**
-	 * @return The unexpected status of the HTTP request
-	 */
-	public int getStatus() {
-		return this.status;
+	protected OpenViduException(String message, Throwable cause) {
+		super(message, cause);
 	}
 
 }

--- a/openvidu-java-client/src/main/java/io/openvidu/java/client/OpenViduJavaClientException.java
+++ b/openvidu-java-client/src/main/java/io/openvidu/java/client/OpenViduJavaClientException.java
@@ -20,7 +20,7 @@ package io.openvidu.java.client;
 /**
  * Defines unexpected internal errors in OpenVidu Java Client
  */
-public class OpenViduJavaClientException extends Exception {
+public class OpenViduJavaClientException extends OpenViduException {
 
 	private static final long serialVersionUID = 1L;
 

--- a/openvidu-java-client/src/test/java/io/openvidu/java/client/OpenViduHttpExceptionTest.java
+++ b/openvidu-java-client/src/test/java/io/openvidu/java/client/OpenViduHttpExceptionTest.java
@@ -1,0 +1,11 @@
+package io.openvidu.java.client;
+
+import org.junit.Test;
+
+public class OpenViduHttpExceptionTest {
+
+    @Test(expected = OpenViduException.class)
+    public void shouldThrowGenericOpenViduException() throws OpenViduHttpException {
+        throw new OpenViduHttpException(401);
+    }
+}

--- a/openvidu-java-client/src/test/java/io/openvidu/java/client/OpenViduJavaClientExceptionTest.java
+++ b/openvidu-java-client/src/test/java/io/openvidu/java/client/OpenViduJavaClientExceptionTest.java
@@ -1,0 +1,11 @@
+package io.openvidu.java.client;
+
+import org.junit.Test;
+
+public class OpenViduJavaClientExceptionTest {
+
+    @Test(expected = OpenViduException.class)
+    public void shouldThrowGenericOpenViduException() throws OpenViduJavaClientException {
+        throw new OpenViduJavaClientException("message");
+    }
+}


### PR DESCRIPTION
Since `OpenViduHttpException` and `OpenViduJavaClientException` are checked exceptions, it forces us to catch (usually) both exceptions when using OpenVidu client. If in the future a new checked exception is added in this lib, we will have to add that new exception everywhere in our catches.

This PR creates a generic OpenVidu exception in which all current exception uses it as base class. This allow the developer to catch OpenViduException alone, without the need to catch those two exceptions everywhere. If for some reason the developer must catch a specific OpenVidu exception, then it may just ignore this generic OpenVidu exception and catch the specific one.

This approach is based on the MinioClient library, which has a lot of specific exceptions and one generic above all, which avoid us catching dozens of exceptions everywhere.

I also changed the `pom.xml` to `2.13.0`, but I think this will confuse users regarding the OpenVidu version as a whole. I can change that to `2.12.2` if necessary.