### PR TITLE
Fix 'on' and 'once' memory leak

### DIFF
--- a/openvidu-browser/src/OpenVidu/Session.ts
+++ b/openvidu-browser/src/OpenVidu/Session.ts
@@ -589,14 +589,7 @@ export class Session implements EventDispatcher {
      */
     on(type: string, handler: (event: SessionDisconnectedEvent | SignalEvent | StreamEvent | ConnectionEvent | PublisherSpeakingEvent | RecordingEvent) => void): EventDispatcher {
 
-        this.ee.on(type, event => {
-            if (event) {
-                console.info("Event '" + type + "' triggered by 'Session'", event);
-            } else {
-                console.info("Event '" + type + "' triggered by 'Session'");
-            }
-            handler(event);
-        });
+        this.ee.on(type, handler);
 
         if (type === 'publisherStartSpeaking') {
             this.startSpeakingEventsEnabled = true;
@@ -628,14 +621,7 @@ export class Session implements EventDispatcher {
      */
     once(type: string, handler: (event: SessionDisconnectedEvent | SignalEvent | StreamEvent | ConnectionEvent | PublisherSpeakingEvent | RecordingEvent) => void): Session {
 
-        this.ee.once(type, event => {
-            if (event) {
-                console.info("Event '" + type + "' triggered once by 'Session'", event);
-            } else {
-                console.info("Event '" + type + "' triggered once by 'Session'");
-            }
-            handler(event);
-        });
+        this.ee.once(type, handler);
 
         if (type === 'publisherStartSpeaking') {
             this.startSpeakingEventsEnabledOnce = true;
@@ -669,7 +655,7 @@ export class Session implements EventDispatcher {
         if (!handler) {
             this.ee.removeAllListeners(type);
         } else {
-            this.ee.off(type, handler);
+            this.ee.removeListener(type, handler);
         }
 
         if (type === 'publisherStartSpeaking') {

--- a/openvidu-browser/src/OpenVidu/Stream.ts
+++ b/openvidu-browser/src/OpenVidu/Stream.ts
@@ -265,14 +265,7 @@ export class Stream implements EventDispatcher {
      * See [[EventDispatcher.on]]
      */
     on(type: string, handler: (event: Event) => void): EventDispatcher {
-        this.ee.on(type, event => {
-            if (event) {
-                console.info("Event '" + type + "' triggered by stream '" + this.streamId + "'", event);
-            } else {
-                console.info("Event '" + type + "' triggered by stream '" + this.streamId + "'");
-            }
-            handler(event);
-        });
+        this.ee.on(type, handler);
         return this;
     }
 
@@ -281,14 +274,7 @@ export class Stream implements EventDispatcher {
      * See [[EventDispatcher.once]]
      */
     once(type: string, handler: (event: Event) => void): EventDispatcher {
-        this.ee.once(type, event => {
-            if (event) {
-                console.info("Event '" + type + "' triggered once by stream '" + this.streamId + "'", event);
-            } else {
-                console.info("Event '" + type + "' triggered once by stream '" + this.streamId + "'");
-            }
-            handler(event);
-        });
+        this.ee.once(type, handler);
         return this;
     }
 

--- a/openvidu-browser/src/OpenVidu/StreamManager.ts
+++ b/openvidu-browser/src/OpenVidu/StreamManager.ts
@@ -149,14 +149,7 @@ export class StreamManager implements EventDispatcher {
      * See [[EventDispatcher.on]]
      */
     on(type: string, handler: (event: Event) => void): EventDispatcher {
-        this.ee.on(type, event => {
-            if (event) {
-                console.info("Event '" + type + "' triggered by '" + (this.remote ? 'Subscriber' : 'Publisher') + "'", event);
-            } else {
-                console.info("Event '" + type + "' triggered by '" + (this.remote ? 'Subscriber' : 'Publisher') + "'");
-            }
-            handler(event);
-        });
+        this.ee.on(type, handler);
         if (type === 'videoElementCreated') {
             if (!!this.stream && this.lazyLaunchVideoElementCreatedEvent) {
                 this.ee.emitEvent('videoElementCreated', [new VideoElementEvent(this.videos[0].video, this, 'videoElementCreated')]);
@@ -183,14 +176,7 @@ export class StreamManager implements EventDispatcher {
      * See [[EventDispatcher.once]]
      */
     once(type: string, handler: (event: Event) => void): StreamManager {
-        this.ee.once(type, event => {
-            if (event) {
-                console.info("Event '" + type + "' triggered once by '" + (this.remote ? 'Subscriber' : 'Publisher') + "'", event);
-            } else {
-                console.info("Event '" + type + "' triggered once by '" + (this.remote ? 'Subscriber' : 'Publisher') + "'");
-            }
-            handler(event);
-        });
+        this.ee.once(type, handler);
         if (type === 'videoElementCreated') {
             if (!!this.stream && this.lazyLaunchVideoElementCreatedEvent) {
                 this.ee.emitEvent('videoElementCreated', [new VideoElementEvent(this.videos[0].video, this, 'videoElementCreated')]);


### PR DESCRIPTION
The current implementation of `.on` and `.once` on several entities is wrong. The only way to have `.off` to work is being able to point the the same original function. In the code each handler is wrapped by a custom handler (for log purposes) making `.off` impossible. This leads to memory leaks