### PR TITLE
Suggest timezone configuration as JAVA_OPTIONS

### DIFF
--- a/openvidu-server/docker/openvidu-docker-compose/.env
+++ b/openvidu-server/docker/openvidu-docker-compose/.env
@@ -134,4 +134,4 @@ OPENVIDU_CDR_PATH=/opt/openvidu/cdr
 # Uncomment the next line and define this to add
 # options to java command
 # Documentation: https://docs.oracle.com/cd/E37116_01/install.111210/e23737/configuring_jvm.htm#OUDIG00058
-# JAVA_OPTIONS=-Xms2048m -Xmx4096m
+# JAVA_OPTIONS=-Xms2048m -Xmx4096m -Duser.timezone=UTC


### PR DESCRIPTION
Before 2.13 we deployed OpenVidu's .jar directly on the host, which means it would use the host timezone, which usually is the desired one. As of 2.13 OpenVidu's .jar is now in a docker image, which uses it's own timezone (default to UTC). If the .env have a default timezone property, it will make clear to the user that the jar will run using that specific timezone, forcing it to change to the desired value. Otherwise it will run using the container's default timezone, and the user may take some time to realize the OpenVidu server is running on a different timezone. This doesn't affect timestamps, but affects the OpenVidu Server logs, which may cause problems when using a log aggregator based on the log date and time.