### PR TITLE
Fix handling of audioSource and videoSource (as videoTrack/audioTrack) in initPublisher

### DIFF
--- a/openvidu-browser/src/OpenVidu/Publisher.ts
+++ b/openvidu-browser/src/OpenVidu/Publisher.ts
@@ -610,7 +610,10 @@ export class Publisher extends StreamManager {
             this.openvidu.generateMediaConstraints(this.properties)
                 .then(myConstraints => {
 
-                    if (myConstraints.constraints === undefined) {
+                    if (myConstraints.constraints === undefined ||
+                      !!myConstraints.videoTrack && !!myConstraints.audioTrack ||
+                      !!myConstraints.audioTrack && myConstraints.constraints?.video === false ||
+                      !!myConstraints.videoTrack && myConstraints.constraints?.audio === false) {
                         // No need to call getUserMedia at all. MediaStreamTracks already provided
                         successCallback(this.openvidu.addAlreadyProvidedTracks(myConstraints, new MediaStream()));
                         // Return as we do not need to process further


### PR DESCRIPTION
When Publisher.ts in the constructor checks if the MediaStreamTracks are provided, it checks if the constraints returned by openvidu.generateMediaConstraints is undefined, however that's never the case, it's reported through audioTrack / videoTrack fields being filled.

This pull request fixes check for this condition consistently with existing code in [openvidu-browser/src/OpenVidu/OpenVidu.ts:556-560](https://github.com/OpenVidu/openvidu/blob/db78b752ef62948e63f166a21919593c49821264/openvidu-browser/src/OpenVidu/OpenVidu.ts#L556-L560)

The issue is reported as #456 