### PR TITLE
openvidu-server: add container dependency

### DIFF
--- a/openvidu-server/docker/openvidu-docker-compose/docker-compose.override.yml
+++ b/openvidu-server/docker/openvidu-docker-compose/docker-compose.override.yml
@@ -9,6 +9,8 @@ services:
         restart: on-failure
         ports:
             - "5442:80"
-        environment: 
+        environment:
             - OPENVIDU_URL=https://${DOMAIN_OR_PUBLIC_IP}:${HTTPS_PORT:-443}
             - OPENVIDU_SECRET=${OPENVIDU_SECRET}
+        depends_on:
+            - openvidu-server

--- a/openvidu-server/docker/openvidu-docker-compose/docker-compose.yml
+++ b/openvidu-server/docker/openvidu-docker-compose/docker-compose.yml
@@ -34,6 +34,10 @@ services:
             - SERVER_PORT=5443
             - KMS_URIS=["ws://localhost:8888/kurento"]
             - COTURN_REDIS_IP=127.0.0.1
+        depends_on:
+            - kms
+            - coturn
+            - nginx
 
     kms:
         image: ${KMS_IMAGE:-kurento/kurento-media-server:6.13.1}
@@ -65,6 +69,8 @@ services:
             - DB_PASSWORD=turn
             - MIN_PORT=57001
             - MAX_PORT=65535
+        depends_on:
+            - redis
 
     nginx:
         image: openvidu/openvidu-proxy:2.0.0-beta3


### PR DESCRIPTION
Since `docker-compose.yml` is a compose file that targets a production environment (and not just a development environment), would be nice for it to have a dependency configuration for the containers.

This way when the OpenVidu stack starts, docker-compose will ensure (almost aways) that `openvidu-server` container will have all other containers already running and working.