### PR TITLE
Fix issue with http when server.ssl.enabled is set to false

### DIFF
--- a/openvidu-browser/src/OpenVidu/Session.ts
+++ b/openvidu-browser/src/OpenVidu/Session.ts
@@ -1288,8 +1288,10 @@ export class Session extends EventDispatcher {
                 }
             }
 
-            this.openvidu.wsUri = 'wss://' + url.host + '/openvidu';
-            this.openvidu.httpUri = 'https://' + url.host;
+            const isHttps = token.startsWith("wss://");
+
+            this.openvidu.wsUri = url.protocol + url.host + '/openvidu';
+            this.openvidu.httpUri = (isHttps ? 'https://': 'http://') + url.host;
 
         } else {
             logger.error('Token "' + token + '" is not valid')

--- a/openvidu-server/src/main/java/io/openvidu/server/config/OpenviduConfig.java
+++ b/openvidu-server/src/main/java/io/openvidu/server/config/OpenviduConfig.java
@@ -565,9 +565,15 @@ public class OpenviduConfig {
 			this.configProps.remove("OPENVIDU_DOMAIN_OR_PUBLIC_IP");
 		}
 
+		String sslEnabled = getValue("server.ssl.enabled");
+		if(sslEnabled == null){
+			sslEnabled = getValue("SERVER_SSL_ENABLED");
+		}
+		String prefix = sslEnabled.equalsIgnoreCase("false") ? "http://": "https://";
+
 		if (domain != null && !domain.isEmpty()) {
 			this.domainOrPublicIp = domain;
-			this.openviduPublicUrl = "https://" + domain;
+			this.openviduPublicUrl = prefix + domain;
 			if (this.httpsPort != null && this.httpsPort != 443) {
 				this.openviduPublicUrl += (":" + this.httpsPort);
 			}
@@ -619,7 +625,7 @@ public class OpenviduConfig {
 		if (publicUrl.startsWith("https://")) {
 			OpenViduServer.wsUrl = publicUrl.replace("https://", "wss://");
 		} else if (publicUrl.startsWith("http://")) {
-			OpenViduServer.wsUrl = publicUrl.replace("http://", "wss://");
+			OpenViduServer.wsUrl = publicUrl.replace("http://", "ws://");
 		}
 		if (OpenViduServer.wsUrl.endsWith("/")) {
 			OpenViduServer.wsUrl = OpenViduServer.wsUrl.substring(0, OpenViduServer.wsUrl.length() - 1);


### PR DESCRIPTION
## What does this PR do
- It ensures that the video and audio stream works whenever `server.ssl.enabled` environment variable is set to `false`

## Description.
Using the current configuration for setting up openvidu, the video and audio stream works just fine. But when the variable `server.ssl.enabled` is set to false, the streams do not work.

## Bug cause.
This is due to the web sockets connecting to `wss://` instead of `ws://` when https is disabled. Which happens on both `openvidu-browser` and `openvidu-server`. 

## The fix
The fix is to ensure that if `server.ssl.enabled` or `SERVER_SSL_ENABLED` is set to false, the openvidu server will run on `http` and the openvidu browser client will connect the web sockets on `ws://` and not `wss://`