### PR TITLE
Fix crash on react native due to check for userAgent in navigator

### DIFF
--- a/openvidu-browser/src/OpenViduInternal/ScreenSharing/Screen-Capturing.js
+++ b/openvidu-browser/src/OpenViduInternal/ScreenSharing/Screen-Capturing.js
@@ -3,15 +3,17 @@ var chromeMediaSource = 'screen';
 var sourceId;
 var screenCallback;
 var isFirefox = typeof window.InstallTrigger !== 'undefined';
-var isOpera = !!window.opera || navigator.userAgent.indexOf(' OPR/') >= 0;
+var isOpera = !!window.opera || (navigator.userAgent && navigator.userAgent.indexOf(' OPR/') >= 0);
 var isChrome = !!window.chrome && !isOpera;
 
-window.addEventListener('message', function (event) {
-    if (event.origin != window.location.origin) {
-        return;
-    }
-    onMessageCallback(event.data);
-});
+if(window.addEventListener){
+    window.addEventListener('message', function (event) {
+        if (event.origin != window.location.origin) {
+            return;
+        }
+        onMessageCallback(event.data);
+    });
+}
 
 // and the function that handles received messages
 function onMessageCallback(data) {


### PR DESCRIPTION
Using `openvidu-browser` in react native (v0.62.2) causes a crash since `navigator.userAgent` is undefined.

`window.addEventListener` is undefined in react native as well. 

Fixing this for individuals with the interest to use openvidu-browser on the react native applications.

Reference:
[https://github.com/facebook/react-native/blob/master/Libraries/Core/setUpNavigator.js](https://github.com/facebook/react-native/blob/master/Libraries/Core/setUpNavigator.js)