### PR TITLE
Added network cache param to IP cameras

### DIFF
--- a/openvidu-server/src/main/java/io/openvidu/server/cdr/CDREventWebrtcConnection.java
+++ b/openvidu-server/src/main/java/io/openvidu/server/cdr/CDREventWebrtcConnection.java
@@ -69,7 +69,7 @@ public class CDREventWebrtcConnection extends CDREventEnd implements Comparable<
 				if (kMediaOptions.rtspUri != null) {
 					json.addProperty("rtspUri", kMediaOptions.rtspUri);
 					json.addProperty("adaptativeBitrate", kMediaOptions.adaptativeBitrate);
-					json.addProperty("networkCache", kMediaOptions.network_cache);
+					json.addProperty("networkCache", kMediaOptions.networkCache);
 					json.addProperty("onlyPlayWithSubscribers", kMediaOptions.onlyPlayWithSubscribers);
 				}
 			}

--- a/openvidu-server/src/main/java/io/openvidu/server/cdr/CDREventWebrtcConnection.java
+++ b/openvidu-server/src/main/java/io/openvidu/server/cdr/CDREventWebrtcConnection.java
@@ -69,6 +69,7 @@ public class CDREventWebrtcConnection extends CDREventEnd implements Comparable<
 				if (kMediaOptions.rtspUri != null) {
 					json.addProperty("rtspUri", kMediaOptions.rtspUri);
 					json.addProperty("adaptativeBitrate", kMediaOptions.adaptativeBitrate);
+					json.addProperty("networkCache", kMediaOptions.network_cache);
 					json.addProperty("onlyPlayWithSubscribers", kMediaOptions.onlyPlayWithSubscribers);
 				}
 			}

--- a/openvidu-server/src/main/java/io/openvidu/server/kurento/core/KurentoMediaOptions.java
+++ b/openvidu-server/src/main/java/io/openvidu/server/kurento/core/KurentoMediaOptions.java
@@ -32,6 +32,7 @@ public class KurentoMediaOptions extends MediaOptions {
 	public String rtspUri;
 	public Boolean adaptativeBitrate;
 	public Boolean onlyPlayWithSubscribers;
+	public Integer network_cache;
 
 	public KurentoMediaOptions(boolean isOffer, String sdpOffer, Boolean hasAudio, Boolean hasVideo,
 			Boolean audioActive, Boolean videoActive, String typeOfVideo, Integer frameRate, String videoDimensions,
@@ -45,7 +46,7 @@ public class KurentoMediaOptions extends MediaOptions {
 	public KurentoMediaOptions(boolean isOffer, String sdpOffer, Boolean hasAudio, Boolean hasVideo,
 			Boolean audioActive, Boolean videoActive, String typeOfVideo, Integer frameRate, String videoDimensions,
 			KurentoFilter filter, boolean doLoopback, String rtspUri, Boolean adaptativeBitrate,
-			Boolean onlyPlayWithSubscribers) {
+			Boolean onlyPlayWithSubscribers, Integer network_cache) {
 		super(hasAudio, hasVideo, audioActive, videoActive, typeOfVideo, frameRate, videoDimensions, filter);
 		this.isOffer = isOffer;
 		this.sdpOffer = sdpOffer;
@@ -53,6 +54,7 @@ public class KurentoMediaOptions extends MediaOptions {
 		this.rtspUri = rtspUri;
 		this.adaptativeBitrate = adaptativeBitrate;
 		this.onlyPlayWithSubscribers = onlyPlayWithSubscribers;
+		this.network_cache = network_cache;
 	}
 
 	public KurentoMediaOptions(Boolean hasAudio, Boolean hasVideo, Boolean audioActive, Boolean videoActive,
@@ -65,6 +67,7 @@ public class KurentoMediaOptions extends MediaOptions {
 		this.rtspUri = streamProperties.rtspUri;
 		this.adaptativeBitrate = streamProperties.adaptativeBitrate;
 		this.onlyPlayWithSubscribers = streamProperties.onlyPlayWithSubscribers;
+		this.network_cache = streamProperties.network_cache;
 	}
 
 	@Override
@@ -75,6 +78,9 @@ public class KurentoMediaOptions extends MediaOptions {
 		}
 		if (onlyPlayWithSubscribers != null) {
 			json.addProperty("onlyPlayWithSubscribers", onlyPlayWithSubscribers);
+		}
+		if (network_cache != null) {
+			json.addProperty("networkCache", network_cache);
 		}
 		return json;
 	}

--- a/openvidu-server/src/main/java/io/openvidu/server/kurento/core/KurentoMediaOptions.java
+++ b/openvidu-server/src/main/java/io/openvidu/server/kurento/core/KurentoMediaOptions.java
@@ -32,7 +32,7 @@ public class KurentoMediaOptions extends MediaOptions {
 	public String rtspUri;
 	public Boolean adaptativeBitrate;
 	public Boolean onlyPlayWithSubscribers;
-	public Integer network_cache;
+	public Integer networkCache;
 
 	public KurentoMediaOptions(boolean isOffer, String sdpOffer, Boolean hasAudio, Boolean hasVideo,
 			Boolean audioActive, Boolean videoActive, String typeOfVideo, Integer frameRate, String videoDimensions,
@@ -46,7 +46,7 @@ public class KurentoMediaOptions extends MediaOptions {
 	public KurentoMediaOptions(boolean isOffer, String sdpOffer, Boolean hasAudio, Boolean hasVideo,
 			Boolean audioActive, Boolean videoActive, String typeOfVideo, Integer frameRate, String videoDimensions,
 			KurentoFilter filter, boolean doLoopback, String rtspUri, Boolean adaptativeBitrate,
-			Boolean onlyPlayWithSubscribers, Integer network_cache) {
+			Boolean onlyPlayWithSubscribers, Integer networkCache) {
 		super(hasAudio, hasVideo, audioActive, videoActive, typeOfVideo, frameRate, videoDimensions, filter);
 		this.isOffer = isOffer;
 		this.sdpOffer = sdpOffer;
@@ -54,7 +54,7 @@ public class KurentoMediaOptions extends MediaOptions {
 		this.rtspUri = rtspUri;
 		this.adaptativeBitrate = adaptativeBitrate;
 		this.onlyPlayWithSubscribers = onlyPlayWithSubscribers;
-		this.network_cache = network_cache;
+		this.networkCache = networkCache;
 	}
 
 	public KurentoMediaOptions(Boolean hasAudio, Boolean hasVideo, Boolean audioActive, Boolean videoActive,
@@ -67,7 +67,7 @@ public class KurentoMediaOptions extends MediaOptions {
 		this.rtspUri = streamProperties.rtspUri;
 		this.adaptativeBitrate = streamProperties.adaptativeBitrate;
 		this.onlyPlayWithSubscribers = streamProperties.onlyPlayWithSubscribers;
-		this.network_cache = streamProperties.network_cache;
+		this.networkCache = streamProperties.networkCache;
 	}
 
 	@Override
@@ -79,8 +79,8 @@ public class KurentoMediaOptions extends MediaOptions {
 		if (onlyPlayWithSubscribers != null) {
 			json.addProperty("onlyPlayWithSubscribers", onlyPlayWithSubscribers);
 		}
-		if (network_cache != null) {
-			json.addProperty("networkCache", network_cache);
+		if (networkCache != null) {
+			json.addProperty("networkCache", networkCache);
 		}
 		return json;
 	}

--- a/openvidu-server/src/main/java/io/openvidu/server/kurento/endpoint/MediaEndpoint.java
+++ b/openvidu-server/src/main/java/io/openvidu/server/kurento/endpoint/MediaEndpoint.java
@@ -364,6 +364,9 @@ public abstract class MediaEndpoint {
 			if (!mediaOptions.adaptativeBitrate) {
 				playerBuilder = playerBuilder.useEncodedMedia();
 			}
+			if (mediaOptions.network_cache != null) {
+				playerBuilder = playerBuilder.withNetworkCache(mediaOptions.network_cache);
+			}
 
 			playerBuilder.buildAsync(new Continuation<PlayerEndpoint>() {
 

--- a/openvidu-server/src/main/java/io/openvidu/server/kurento/endpoint/MediaEndpoint.java
+++ b/openvidu-server/src/main/java/io/openvidu/server/kurento/endpoint/MediaEndpoint.java
@@ -364,8 +364,8 @@ public abstract class MediaEndpoint {
 			if (!mediaOptions.adaptativeBitrate) {
 				playerBuilder = playerBuilder.useEncodedMedia();
 			}
-			if (mediaOptions.network_cache != null) {
-				playerBuilder = playerBuilder.withNetworkCache(mediaOptions.network_cache);
+			if (mediaOptions.networkCache != null) {
+				playerBuilder = playerBuilder.withNetworkCache(mediaOptions.networkCache);
 			}
 
 			playerBuilder.buildAsync(new Continuation<PlayerEndpoint>() {

--- a/openvidu-server/src/main/java/io/openvidu/server/rest/SessionRestController.java
+++ b/openvidu-server/src/main/java/io/openvidu/server/rest/SessionRestController.java
@@ -755,12 +755,19 @@ public class SessionRestController {
 		String rtspUri;
 		Boolean adaptativeBitrate;
 		Boolean onlyPlayWithSubscribers;
+		String network_cache_str;
+		Integer network_cache;
 		String data;
 		try {
 			type = (String) params.get("type");
 			rtspUri = (String) params.get("rtspUri");
 			adaptativeBitrate = (Boolean) params.get("adaptativeBitrate");
 			onlyPlayWithSubscribers = (Boolean) params.get("onlyPlayWithSubscribers");
+			network_cache_str = (String) params.get("networkCache");
+			if (network_cache_str != null) 
+				network_cache = Integer.parseInt(network_cache_str);
+			else
+				network_cache = null;
 			data = (String) params.get("data");
 		} catch (ClassCastException e) {
 			return this.generateErrorResponse("Type error in some parameter",
@@ -785,7 +792,7 @@ public class SessionRestController {
 		String videoDimensions = null;
 		KurentoMediaOptions mediaOptions = new KurentoMediaOptions(true, null, hasAudio, hasVideo, audioActive,
 				videoActive, typeOfVideo, frameRate, videoDimensions, null, false, rtspUri, adaptativeBitrate,
-				onlyPlayWithSubscribers);
+				onlyPlayWithSubscribers, network_cache);
 
 		// While closing a session IP cameras can't be published
 		if (session.closingLock.readLock().tryLock()) {

--- a/openvidu-server/src/main/java/io/openvidu/server/rest/SessionRestController.java
+++ b/openvidu-server/src/main/java/io/openvidu/server/rest/SessionRestController.java
@@ -755,19 +755,19 @@ public class SessionRestController {
 		String rtspUri;
 		Boolean adaptativeBitrate;
 		Boolean onlyPlayWithSubscribers;
-		String network_cache_str;
-		Integer network_cache;
+		String networkCacheStr;
+		Integer networkCache;
 		String data;
 		try {
 			type = (String) params.get("type");
 			rtspUri = (String) params.get("rtspUri");
 			adaptativeBitrate = (Boolean) params.get("adaptativeBitrate");
 			onlyPlayWithSubscribers = (Boolean) params.get("onlyPlayWithSubscribers");
-			network_cache_str = (String) params.get("networkCache");
-			if (network_cache_str != null) 
-				network_cache = Integer.parseInt(network_cache_str);
+			networkCacheStr = (String) params.get("networkCache");
+			if (networkCacheStr != null) 
+				networkCache = Integer.parseInt(networkCacheStr);
 			else
-				network_cache = null;
+				networkCache = null;
 			data = (String) params.get("data");
 		} catch (ClassCastException e) {
 			return this.generateErrorResponse("Type error in some parameter",
@@ -792,7 +792,7 @@ public class SessionRestController {
 		String videoDimensions = null;
 		KurentoMediaOptions mediaOptions = new KurentoMediaOptions(true, null, hasAudio, hasVideo, audioActive,
 				videoActive, typeOfVideo, frameRate, videoDimensions, null, false, rtspUri, adaptativeBitrate,
-				onlyPlayWithSubscribers, network_cache);
+				onlyPlayWithSubscribers, networkCache);
 
 		// While closing a session IP cameras can't be published
 		if (session.closingLock.readLock().tryLock()) {


### PR DESCRIPTION
network cache parameter in Kurento allows to define a buffer in ms that will be used when playing from remote RTSP cameras. If not present this buffers defaults to 2 seconds which in many use cases is too much to allow the IP cameras functionality to be really useful.
This PR just adds an optional parameter (called "networkCache") in the REST API that publish from IP cameras, if that parameter is present and represents a number, it will be used to define the network cache  buffer size in miliseconds when opening the Player Element in Kurento