### PR TITLE
[WIP]: openvidu-browser: Wrapped platform library

### DIFF
--- a/openvidu-browser/src/OpenVidu/LocalRecorder.ts
+++ b/openvidu-browser/src/OpenVidu/LocalRecorder.ts
@@ -17,8 +17,8 @@
 
 import { Stream } from './Stream';
 import { LocalRecorderState } from '../OpenViduInternal/Enums/LocalRecorderState';
-import platform = require('platform');
 import { OpenViduLogger } from '../OpenViduInternal/Logger/OpenViduLogger';
+import { PlatformUtils } from '../OpenViduInternal/Utils/Platform';
 
 
 /**
@@ -29,6 +29,11 @@ declare var MediaRecorder: any;
  * @hidden
  */
 const logger: OpenViduLogger = OpenViduLogger.getInstance();
+
+/**
+ * @hidden
+ */
+const platform: PlatformUtils = PlatformUtils.getInstance();
 
 
 /**
@@ -211,7 +216,7 @@ export class LocalRecorder {
         this.videoPreview.id = this.id;
         this.videoPreview.autoplay = true;
 
-        if (platform.name === 'Safari') {
+        if (platform.isSafariBrowser()) {
             this.videoPreview.setAttribute('playsinline', 'true');
         }
 

--- a/openvidu-browser/src/OpenVidu/Session.ts
+++ b/openvidu-browser/src/OpenVidu/Session.ts
@@ -40,14 +40,18 @@ import { StreamPropertyChangedEvent } from '../OpenViduInternal/Events/StreamPro
 import { NetworkQualityLevelChangedEvent } from '../OpenViduInternal/Events/NetworkQualityLevelChangedEvent';
 import { OpenViduError, OpenViduErrorName } from '../OpenViduInternal/Enums/OpenViduError';
 import { VideoInsertMode } from '../OpenViduInternal/Enums/VideoInsertMode';
-
-import platform = require('platform');
 import { OpenViduLogger } from '../OpenViduInternal/Logger/OpenViduLogger';
+import { PlatformUtils } from '../OpenViduInternal/Utils/Platform';
 
 /**
  * @hidden
  */
 const logger: OpenViduLogger = OpenViduLogger.getInstance();
+
+/**
+ * @hidden
+ */
+const platform: PlatformUtils = PlatformUtils.getInstance();
 
 /**
  * Represents a video call. It can also be seen as a videoconference room where multiple users can connect.
@@ -193,7 +197,7 @@ export class Session extends EventDispatcher {
                     reject(error);
                 });
             } else {
-                reject(new OpenViduError(OpenViduErrorName.BROWSER_NOT_SUPPORTED, 'Browser ' + platform.name + ' (version ' + platform.version + ') for ' + platform.os!!.family + ' is not supported in OpenVidu'));
+                reject(new OpenViduError(OpenViduErrorName.BROWSER_NOT_SUPPORTED, 'Browser ' + platform.getName() + ' (version ' + platform.getVersion() + ') for ' + platform.getFamily() + ' is not supported in OpenVidu'));
             }
         });
     }
@@ -1122,7 +1126,7 @@ export class Session extends EventDispatcher {
         const joinParams = {
             token: (!!token) ? token : '',
             session: this.sessionId,
-            platform: !!platform.description ? platform.description : 'unknown',
+            platform: !!platform.getDescription() ? platform.getDescription() : 'unknown',
             metadata: !!this.options.metadata ? this.options.metadata : '',
             secret: this.openvidu.getSecret(),
             recorder: this.openvidu.getRecorder()
@@ -1132,10 +1136,10 @@ export class Session extends EventDispatcher {
 
     sendVideoData(streamManager: StreamManager, intervalSeconds: number = 1) {
         if(
-            this.openvidu.isChromeBrowser() || this.openvidu.isChromeMobileBrowser() || this.openvidu.isOperaBrowser() ||
-            this.openvidu.isOperaMobileBrowser() || this.openvidu.isElectron() || this.openvidu.isSafariBrowser() ||
-            this.openvidu.isAndroidBrowser() || this.openvidu.isSamsungBrowser() ||
-            (this.openvidu.isIPhoneOrIPad() && this.openvidu.isIOSWithSafari())
+            platform.isChromeBrowser() || platform.isChromeMobileBrowser() || platform.isOperaBrowser() ||
+            platform.isOperaMobileBrowser() || platform.isElectron() || platform.isSafariBrowser() ||
+            platform.isAndroidBrowser() || platform.isSamsungBrowser() ||
+            (platform.isIPhoneOrIPad() && platform.isIOSWithSafari())
         ) {
             setTimeout(async () => {
                 const statsMap = await streamManager.stream.getWebRtcPeer().pc.getStats();
@@ -1154,7 +1158,7 @@ export class Session extends EventDispatcher {
                     }
                 });
             }, intervalSeconds * 1000);
-        } else if (this.openvidu.isFirefoxBrowser() || this.openvidu.isFirefoxMobileBrowser()) {
+        } else if (platform.isFirefoxBrowser() || platform.isFirefoxMobileBrowser()) {
             // Basic version for Firefox. It does not support stats
             this.openvidu.sendRequest('videoData', {
                 height: streamManager.stream.videoDimensions.height,
@@ -1167,7 +1171,7 @@ export class Session extends EventDispatcher {
                 }
             });
         } else {
-            console.error('Browser ' + platform.name + ' (version ' + platform.version + ') for ' + platform.os!!.family + ' is not supported in OpenVidu for Network Quality');
+            logger.error('Browser ' + platform.getName() + ' (version ' + platform.getVersion() + ') for ' + platform.getFamily() + ' is not supported in OpenVidu for Network Quality');
         }
     }
 

--- a/openvidu-browser/src/OpenVidu/Stream.ts
+++ b/openvidu-browser/src/OpenVidu/Stream.ts
@@ -30,19 +30,22 @@ import { PublisherSpeakingEvent } from '../OpenViduInternal/Events/PublisherSpea
 import { StreamManagerEvent } from '../OpenViduInternal/Events/StreamManagerEvent';
 import { StreamPropertyChangedEvent } from '../OpenViduInternal/Events/StreamPropertyChangedEvent';
 import { OpenViduError, OpenViduErrorName } from '../OpenViduInternal/Enums/OpenViduError';
+import { OpenViduLogger } from '../OpenViduInternal/Logger/OpenViduLogger';
+import { PlatformUtils } from '../OpenViduInternal/Utils/Platform';
 
 /**
  * @hidden
  */
 import hark = require('hark');
-import platform = require('platform');
-import { OpenViduLogger } from '../OpenViduInternal/Logger/OpenViduLogger';
 /**
  * @hidden
  */
 const logger: OpenViduLogger = OpenViduLogger.getInstance();
 
-
+/**
+ * @hidden
+ */
+const platform: PlatformUtils = PlatformUtils.getInstance();
 
 /**
  * Represents each one of the media streams available in OpenVidu Server for certain session.
@@ -108,7 +111,7 @@ export class Stream extends EventDispatcher {
      * - `"SCREEN"`: when the video source comes from screen-sharing.
      * - `"CUSTOM"`: when [[PublisherProperties.videoSource]] has been initialized in the Publisher side with a custom MediaStreamTrack when calling [[OpenVidu.initPublisher]]).
      * - `"IPCAM"`: when the video source comes from an IP camera participant instead of a regular participant (see [IP cameras](/en/stable/advanced-features/ip-cameras/)).
-     * 
+     *
      * If [[hasVideo]] is false, this property is undefined
      */
     typeOfVideo?: string;
@@ -537,7 +540,7 @@ export class Stream extends EventDispatcher {
      */
     isSendScreen(): boolean {
         let screen = this.outboundStreamOpts.publisherProperties.videoSource === 'screen';
-        if (platform.name === 'Electron') {
+        if (platform.isElectron()) {
             screen = typeof this.outboundStreamOpts.publisherProperties.videoSource === 'string' &&
                 this.outboundStreamOpts.publisherProperties.videoSource.startsWith('screen:');
         }

--- a/openvidu-browser/src/OpenVidu/StreamManager.ts
+++ b/openvidu-browser/src/OpenVidu/StreamManager.ts
@@ -22,13 +22,18 @@ import { Event } from '../OpenViduInternal/Events/Event';
 import { StreamManagerEvent } from '../OpenViduInternal/Events/StreamManagerEvent';
 import { VideoElementEvent } from '../OpenViduInternal/Events/VideoElementEvent';
 import { VideoInsertMode } from '../OpenViduInternal/Enums/VideoInsertMode';
-
-import platform = require('platform');
 import { OpenViduLogger } from '../OpenViduInternal/Logger/OpenViduLogger';
+import { PlatformUtils } from '../OpenViduInternal/Utils/Platform';
+
 /**
  * @hidden
  */
 const logger: OpenViduLogger = OpenViduLogger.getInstance();
+
+/**
+ * @hidden
+ */
+const platform: PlatformUtils = PlatformUtils.getInstance();
 
 /**
  * Interface in charge of displaying the media streams in the HTML DOM. This wraps any [[Publisher]] and [[Subscriber]] object.
@@ -121,7 +126,7 @@ export class StreamManager extends EventDispatcher {
                     id: '',
                     canplayListenerAdded: false
                 };
-                if (platform.name === 'Safari') {
+                if (platform.isSafariBrowser()) {
                     this.firstVideoElement.video.setAttribute('playsinline', 'true');
                 }
                 this.targetElement = targEl;
@@ -379,7 +384,7 @@ export class StreamManager extends EventDispatcher {
         video.autoplay = true;
         video.controls = false;
 
-        if (platform.name === 'Safari') {
+        if (platform.isSafariBrowser()) {
             video.setAttribute('playsinline', 'true');
         }
 
@@ -463,7 +468,7 @@ export class StreamManager extends EventDispatcher {
     updateMediaStream(mediaStream: MediaStream) {
         this.videos.forEach(streamManagerVideo => {
             streamManagerVideo.video.srcObject = mediaStream;
-            if (platform['isIonicIos']) {
+            if (platform.isIonicIos()) {
                 // iOS Ionic. LIMITATION: must reinsert the video in the DOM for
                 // the media stream to be updated
                 const vParent = streamManagerVideo.video.parentElement;
@@ -506,7 +511,7 @@ export class StreamManager extends EventDispatcher {
     }
 
     private mirrorVideo(video): void {
-        if (!platform['isIonicIos']) {
+        if (!platform.isIonicIos()) {
             video.style.transform = 'rotateY(180deg)';
             video.style.webkitTransform = 'rotateY(180deg)';
         }

--- a/openvidu-browser/src/OpenViduInternal/Utils/Platform.ts
+++ b/openvidu-browser/src/OpenViduInternal/Utils/Platform.ts
@@ -1,0 +1,183 @@
+import platform = require("platform");
+
+export class PlatformUtils {
+	private static instance: PlatformUtils;
+	private constructor() {}
+
+	static getInstance(): PlatformUtils {
+		if (!PlatformUtils.instance) {
+			PlatformUtils.instance = new PlatformUtils();
+		}
+		return PlatformUtils.instance;
+	}
+
+	public isChromeBrowser(): boolean {
+		return platform.name === "Chrome";
+	}
+
+	/**
+	 * @hidden
+	 */
+	public isSafariBrowser(): boolean {
+		return platform.name === "Safari";
+	}
+
+	/**
+	 * @hidden
+	 */
+	public isChromeMobileBrowser(): boolean {
+		return platform.name === "Chrome Mobile";
+	}
+
+	/**
+	 * @hidden
+	 */
+	public isFirefoxBrowser(): boolean {
+		return platform.name === "Firefox";
+	}
+
+	/**
+	 * @hidden
+	 */
+	public isFirefoxMobileBrowser(): boolean {
+		return platform.name === "Firefox Mobile";
+	}
+
+	/**
+	 * @hidden
+	 */
+	public isOperaBrowser(): boolean {
+		return platform.name === "Opera";
+	}
+
+	/**
+	 * @hidden
+	 */
+	public isOperaMobileBrowser(): boolean {
+		return platform.name === "Opera Mobile";
+	}
+
+	/**
+	 * @hidden
+	 */
+	public isAndroidBrowser(): boolean {
+		return platform.name === "Android Browser";
+	}
+
+	/**
+	 * @hidden
+	 */
+	public isElectron(): boolean {
+		return platform.name === "Electron";
+	}
+
+	/**
+	 * @hidden
+	 */
+	public isSamsungBrowser(): boolean {
+		return (
+			platform.name === "Samsung Internet Mobile" ||
+			platform.name === "Samsung Internet"
+		);
+	}
+
+	/**
+	 * @hidden
+	 */
+	public isIPhoneOrIPad(): boolean {
+		const userAgent = !!platform.ua ? platform.ua : navigator.userAgent;
+
+		const isTouchable = "ontouchend" in document;
+		const isIPad = /\b(\w*Macintosh\w*)\b/.test(userAgent) && isTouchable;
+		const isIPhone =
+			/\b(\w*iPhone\w*)\b/.test(userAgent) &&
+			/\b(\w*Mobile\w*)\b/.test(userAgent) &&
+			isTouchable;
+
+		return isIPad || isIPhone;
+	}
+
+	/**
+	 * @hidden
+	 */
+	public isIOSWithSafari(): boolean {
+		const userAgent = !!platform.ua ? platform.ua : navigator.userAgent;
+		return (
+			/\b(\w*Apple\w*)\b/.test(navigator.vendor) &&
+			/\b(\w*Safari\w*)\b/.test(userAgent) &&
+			!/\b(\w*CriOS\w*)\b/.test(userAgent) &&
+			!/\b(\w*FxiOS\w*)\b/.test(userAgent)
+		);
+	}
+
+	/**
+	 * @hidden
+	 */
+	public isIonicIos(): boolean {
+		return this.isIPhoneOrIPad() && platform.ua!!.indexOf("Safari") === -1;
+	}
+
+	/**
+	 * @hidden
+	 */
+	public isIonicAndroid(): boolean {
+		return (
+			platform.os!!.family === "Android" && platform.name == "Android Browser"
+		);
+	}
+
+	/**
+	 * @hidden
+	 */
+	public isMobileDevice(): boolean {
+		return platform.os!!.family === "iOS" || platform.os!!.family === "Android";
+	}
+
+	/**
+	 * @hidden
+	 */
+	public canScreenShare(): boolean {
+		const version = platform?.version ? parseFloat(platform.version) : -1;
+
+		// Reject mobile devices
+		if (this.isMobileDevice()) {
+			return false;
+		}
+
+		return (
+			this.isChromeBrowser() ||
+			this.isFirefoxBrowser() ||
+			this.isOperaBrowser() ||
+			this.isElectron() ||
+			(this.isSafariBrowser() && version >= 13)
+		);
+	}
+
+	/**
+	 * @hidden
+	 */
+	public getName(): string {
+		return platform.name || "";
+	}
+
+	/**
+	 * @hidden
+	 */
+	public getVersion(): string {
+		return platform.version || "";
+	}
+
+	/**
+	 * @hidden
+	 */
+	public getFamily(): string {
+		return platform.os!!.family || "";
+	}
+
+	/**
+	 * @hidden
+	 */
+	public getDescription(): string {
+		return platform.description || "";
+	}
+}

--- a/openvidu-browser/src/OpenViduInternal/WebRtcPeer/WebRtcPeer.ts
+++ b/openvidu-browser/src/OpenViduInternal/WebRtcPeer/WebRtcPeer.ts
@@ -17,12 +17,17 @@
 
 import freeice = require('freeice');
 import uuid = require('uuid');
-import platform = require('platform');
 import { OpenViduLogger } from '../Logger/OpenViduLogger';
+import { PlatformUtils } from '../Utils/Platform';
+
 /**
  * @hidden
  */
 const logger: OpenViduLogger = OpenViduLogger.getInstance();
+/**
+ * @hidden
+ */
+const platform: PlatformUtils = PlatformUtils.getInstance();
 
 
 export interface WebRtcPeerConfiguration {
@@ -139,7 +144,7 @@ export class WebRtcPeer {
 
             logger.debug('RTCPeerConnection constraints: ' + JSON.stringify(constraints));
 
-            if (platform.name === 'Safari' && platform.ua!!.indexOf('Safari') !== -1) {
+            if (platform.isSafariBrowser() && !platform.isIonicIos()) {
                 // Safari (excluding Ionic), at least on iOS just seems to support unified plan, whereas in other browsers is not yet ready and considered experimental
                 if (offerAudio) {
                     this.pc.addTransceiver('audio', {
@@ -217,7 +222,7 @@ export class WebRtcPeer {
      * @hidden
      */
     setRemoteDescription(answer: RTCSessionDescriptionInit, needsTimeoutOnProcessAnswer: boolean, resolve: (value?: string | PromiseLike<string> | undefined) => void, reject: (reason?: any) => void) {
-        if (platform['isIonicIos']) {
+        if (platform.isIonicIos()) {
             // Ionic iOS platform
             if (needsTimeoutOnProcessAnswer) {
                 // 400 ms have not elapsed yet since first remote stream triggered Stream#initWebRtcPeerReceive

--- a/openvidu-browser/src/OpenViduInternal/WebRtcStats/WebRtcStats.ts
+++ b/openvidu-browser/src/OpenViduInternal/WebRtcStats/WebRtcStats.ts
@@ -18,13 +18,16 @@
 // tslint:disable:no-string-literal
 
 import { Stream } from '../../OpenVidu/Stream';
-import platform = require('platform');
 import { OpenViduLogger } from '../Logger/OpenViduLogger';
+import { PlatformUtils } from '../Utils/Platform';
 /**
  * @hidden
  */
 const logger: OpenViduLogger = OpenViduLogger.getInstance();
-
+/**
+ * @hidden
+ */
+const platform: PlatformUtils = PlatformUtils.getInstance();
 
 export class WebRtcStats {
 
@@ -103,7 +106,7 @@ export class WebRtcStats {
         return new Promise((resolve, reject) => {
             this.getStatsAgnostic(this.stream.getRTCPeerConnection(),
                 (stats) => {
-                    if ((platform.name!.indexOf('Chrome') !== -1) || (platform.name!.indexOf('Opera') !== -1)) {
+                    if (platform.isChromeBrowser() || platform.isChromeMobileBrowser() || platform.isOperaBrowser() || platform.isOperaMobileBrowser()) {
                         let localCandidateId, remoteCandidateId, googCandidatePair;
                         const localCandidates = {};
                         const remoteCandidates = {};
@@ -181,7 +184,7 @@ export class WebRtcStats {
 
         const f = (stats) => {
 
-            if (platform.name!.indexOf('Firefox') !== -1) {
+            if (platform.isFirefoxBrowser() || platform.isFirefoxMobileBrowser()) {
                 stats.forEach((stat) => {
 
                     let json = {};
@@ -278,7 +281,7 @@ export class WebRtcStats {
                         sendPost(JSON.stringify(json));
                     }
                 });
-            } else if ((platform.name!.indexOf('Chrome') !== -1) || (platform.name!.indexOf('Opera') !== -1)) {
+            } else if (platform.isChromeBrowser() || platform.isChromeMobileBrowser() || platform.isOperaBrowser() || platform.isOperaMobileBrowser()) {
                 for (const key of Object.keys(stats)) {
                     const stat = stats[key];
                     if (stat.type === 'ssrc') {
@@ -377,7 +380,7 @@ export class WebRtcStats {
         logger.log(response);
         const standardReport = {};
 
-        if (platform.name!.indexOf('Firefox') !== -1) {
+        if (platform.isFirefoxBrowser() || platform.isFirefoxMobileBrowser()) {
             Object.keys(response).forEach(key => {
                 logger.log(response[key]);
             });
@@ -400,13 +403,13 @@ export class WebRtcStats {
     }
 
     private getStatsAgnostic(pc, successCb, failureCb) {
-        if (platform.name!.indexOf('Firefox') !== -1) {
+        if (platform.isFirefoxBrowser() || platform.isFirefoxMobileBrowser()) {
             // getStats takes args in different order in Chrome and Firefox
             return pc.getStats(null).then(response => {
                 const report = this.standardizeReport(response);
                 successCb(report);
             }).catch(failureCb);
-        } else if ((platform.name!.indexOf('Chrome') !== -1) || (platform.name!.indexOf('Opera') !== -1)) {
+        } else if (platform.isChromeBrowser() || platform.isChromeMobileBrowser() || platform.isOperaBrowser() || platform.isOperaMobileBrowser()) {
             // In Chrome, the first two arguments are reversed
             return pc.getStats((response) => {
                 const report = this.standardizeReport(response);


### PR DESCRIPTION
With the aim of fixing some problems with the devices and browsers support like #529 (PR #531) and for prevent the future bugs,  platform library has been wrapped in an external file that provides the necessary methods to check each platform and browsers supported in OpenVidu.

Next step: check devices for regressions 