### PR TITLE
openvidu-deployment: Fix cloudformation wait condition

### DIFF
--- a/openvidu-server/deployments/ce/aws/CF-OpenVidu.yaml.template
+++ b/openvidu-server/deployments/ce/aws/CF-OpenVidu.yaml.template
@@ -345,6 +345,7 @@ Resources:
       ResourceSignal:
         Timeout: PT30M
         Count: '1'
+    DependsOn: 'OpenviduServer'
 
   WebServerSecurityGroup:
     Type: 'AWS::EC2::SecurityGroup'


### PR DESCRIPTION
Adds DependsOn to avoid getting stuck waiting for the finish signal after it has already been sent.

Before this change, we were unable to create CloudFormation stack, the wait condition always timed out.