### PR TITLE
openvidu-proxy: Disable Nginx version information

### DIFF
--- a/openvidu-server/docker/openvidu-proxy/nginx.conf
+++ b/openvidu-server/docker/openvidu-proxy/nginx.conf
@@ -27,6 +27,8 @@ http {
 
     #gzip  on;
 
+    server_tokens off;
+
     include /etc/nginx/conf.d/*.conf;
     include /etc/nginx/vhost.d/*.conf;
 }


### PR DESCRIPTION
It is a good practice for server hardening to not display any server component version information, thus this should be disabled for Nginx.