### PR TITLE
openvidu-redis: IPv6 listening (RFC 6540)

### DIFF
--- a/openvidu-server/docker/openvidu-redis/entrypoint.sh
+++ b/openvidu-server/docker/openvidu-redis/entrypoint.sh
@@ -1,6 +1,10 @@
 #!/bin/sh
 
-[ -z "${REDIS_BINDING}" ] && REDIS_BINDING="127.0.0.1"
+if [ -f /proc/net/if_inet6 ]; then
+  [ -z "${REDIS_BINDING}" ] && REDIS_BINDING="127.0.0.1 ::1"
+else
+  [ -z "${REDIS_BINDING}" ] && REDIS_BINDING="127.0.0.1"
+fi
 
 printf "\n"
 printf "\n  ======================================="


### PR DESCRIPTION
Ensure that Redis listens also additionally on the IPv6 socket if the operating system inside the container provides IPv6 support. And as per RFC 6540, IP nowadays means IPv4 and IPv6, not just IPv4-only.

Finally, the common default situation is dual-stack, which this change provides – while still being fully backwards compatible.