### PR TITLE
Filter event not handled

### DIFF
--- a/openvidu-browser/src/OpenVidu/Session.ts
+++ b/openvidu-browser/src/OpenVidu/Session.ts
@@ -1076,8 +1076,13 @@ export class Session extends EventDispatcher {
         const streamId: string = response.streamId;
         this.getConnection(connectionId, 'No connection found for connectionId ' + connectionId)
             .then(connection => {
-                logger.info('Filter event dispatched');
+                logger.info('Filter event dispatched:', response.eventType);
                 const stream: Stream = connection.stream!;
+                if (!stream.filter!.handlers[response.eventType] || typeof stream.filter!.handlers[response.eventType] !== 'function') {
+                    let handlers: string[] = [];
+                    for (const key in stream.filter!.handlers) handlers.push(key);
+                    return logger.error('Filter event not handled or is not a function! Actually filter events handled:', handlers.join(","));
+                }
                 stream.filter!.handlers[response.eventType](new FilterEvent(stream.filter!, response.eventType, response.data));
             });
     }


### PR DESCRIPTION
Hi, I'm using latest 2.16.0 library.

I found a bug using the 'PlateDetectorFilter' filter.
I used this code
```javascript
publisher.stream.applyFilter("PlateDetectorFilter", {})
    .then(filter => {
        filter.addEventListener("PlateDetected", filterEvent => {
            console.log('Plate found!. Data: ' + filterEvent.data);
        });
});
```
When a plate is detected in console this error appear:
**ERROR Error: Uncaught (in promise): TypeError: stream.filter.handlers[response.eventType] is not a function
TypeError: stream.filter.handlers[response.eventType] is not a function**

Debugging the OpenVidu Session lib I discovered that I get a different event than the one eventually managed.
In this case the event I receive is '**plate-detected**', different from '**PlateDetected**'.
But if I try this
```javascript
publisher.stream.applyFilter("PlateDetectorFilter", {})
    .then(filter => {
        filter.addEventListener("plate-detected", filterEvent => {
            console.log('Plate found!. Data: ' + filterEvent.data);
        });
});
```
OpenVidu show this error:
**ERROR Error: Uncaught (in promise): Object: {"code":407,"message":"Request to addFilterEventListener to stream str_CAM_K321_con_Oo1gdkqHtX gone wrong: Event not found (Code:40106, Type:null, Data: {\"type\":\"MEDIA_OBJECT_EVENT_NOT_SUPPORTED\"}). Code: 407","data":"{}","sessionId":"iq7cks92tme25efm7co7sft8ho","requestTime":1606320805489}**

_O.T. The error surely lies in the Kurento Plate Detector module._

This PR manages the error by giving indications on the events issued in console instead of crash.