### PR TITLE
Bugfix/#569 video dimensions on firefox

### DIFF
--- a/openvidu-browser/src/OpenVidu/Session.ts
+++ b/openvidu-browser/src/OpenVidu/Session.ts
@@ -1206,10 +1206,10 @@ export class Session extends EventDispatcher {
         } else if (platform.isFirefoxBrowser() || platform.isFirefoxMobileBrowser() || platform.isIonicIos() || platform.isReactNative()) {
             // Basic version for Firefox and Ionic iOS. They do not support stats
             this.openvidu.sendRequest('videoData', {
-                height: streamManager.stream.videoDimensions.height,
-                width: streamManager.stream.videoDimensions.width,
-                videoActive: streamManager.stream.videoActive,
-                audioActive: streamManager.stream.audioActive
+                height: streamManager.stream.videoDimensions?.height || 0,
+                width: streamManager.stream.videoDimensions?.width || 0,
+                videoActive: streamManager.stream.videoActive != null ? streamManager.stream.videoActive : false,
+                audioActive: streamManager.stream.audioActive != null ? streamManager.stream.audioActive : false
             }, (error, response) => {
                 if (error) {
                     logger.error("Error sending 'videoData' event", error);


### PR DESCRIPTION
- Session: adding fallback values (`0`) to the `height` and `width` in case the stream's `videoDimensions` are not set and adding safe-check in case `videoActive` or `audioActive` were not set