### PR TITLE
Update metricbeat-elasticsearch.yml

### DIFF
--- a/openvidu-server/deployments/pro/docker-compose/media-node/beats/metricbeat-elasticsearch.yml
+++ b/openvidu-server/deployments/pro/docker-compose/media-node/beats/metricbeat-elasticsearch.yml
@@ -1,9 +1,32 @@
 metricbeat.modules:
   - module: system
-    metricsets: [cpu]
-    enabled: true
-    period: ${OPENVIDU_PRO_CLUSTER_LOAD_INTERVAL}s
+    metricsets:
+      - cpu
+        #- diskio
+      - memory
+      - network
+      - filesystem
+      - fsstat
+      #- process
+      - process_summary
+      - uptime
+    filesystem.ignore_types: [nfs, smbfs, autofs, devtmpfs, devpts, hugetlbfs, tmpfs, sysfs, securityfs, cgroup2, cgroup, pstore, debugfs, configfs, fusectl, proc, fuse.lxcfs, squashfs]
     processes: ['.*']
+    #    process.include_top_n:
+    #      by_cpu: 2
+    #      by_memory: 2
+    processors:
+      - drop_event:
+           when:
+              or:
+                - regexp:
+                      system.network.name: '^(veth|lo|docker|br-)($|)'
+                - regexp:
+                      system.filesystem.mount_point: '^/(sys|cgroup|proc|dev|etc|host)($|/)'
+                - regexp:
+                      system.filesystem.mount_point: '^/hostfs/(sys|cgroup|proc|dev|etc|host)($|/)'
+    enabled: true
+    period: ${OPENVIDU_PRO_CLUSTER_LOAD_INTERVAL}0s
     cpu.metrics: [normalized_percentages]
 fields: {ip: "${MEDIA_NODE_IP}", cluster-id: "${CLUSTER_ID}"}
 pipeline:


### PR DESCRIPTION
Changes needed to get metrics from the media node host base system (cpu, memory, disk, network, uptime))
Also changed polling period to 10x so not to oversize elasticsearch storage