### PR TITLE
removed console.error() poluting console output on http failure

### DIFF
--- a/openvidu-node-client/src/OpenVidu.ts
+++ b/openvidu-node-client/src/OpenVidu.ts
@@ -479,11 +479,9 @@ export class OpenVidu {
             // The request was made but no response was received
             // `error.request` is an instance of XMLHttpRequest in the browser and an instance of
             // http.ClientRequest in node.js
-            reject(new Error(error.request));
             reject(error);
           } else {
             // Something happened in setting up the request that triggered an Error
-            reject(new Error(error.message));
             reject(new Error(error.message));
           }
         });

--- a/openvidu-node-client/src/OpenVidu.ts
+++ b/openvidu-node-client/src/OpenVidu.ts
@@ -206,10 +206,10 @@ export class OpenVidu {
             // The request was made but no response was received
             // `error.request` is an instance of XMLHttpRequest in the browser and an instance of
             // http.ClientRequest in node.js
-            console.error(error.request);
+            reject(error.request);
           } else {
             // Something happened in setting up the request that triggered an Error
-            console.error('Error', error.message);
+            reject(error.message);
           }
         });
     });
@@ -259,10 +259,10 @@ export class OpenVidu {
           } else if (error.request) {
             // The request was made but no response was received `error.request` is an instance of XMLHttpRequest
             // in the browser and an instance of http.ClientRequest in node.js
-            console.error(error.request);
+            reject(new Error(error.request));
           } else {
             // Something happened in setting up the request that triggered an Error
-            console.error('Error', error.message);
+            reject(new Error(error.message));
           }
         });
     });
@@ -304,10 +304,10 @@ export class OpenVidu {
             // The request was made but no response was received
             // `error.request` is an instance of XMLHttpRequest in the browser and an instance of
             // http.ClientRequest in node.js
-            console.error(error.request);
+            reject(new Error(error.request));
           } else {
             // Something happened in setting up the request that triggered an Error
-            console.error('Error', error.message);
+            reject(new Error(error.message));
           }
         });
     });
@@ -352,10 +352,10 @@ export class OpenVidu {
             // The request was made but no response was received
             // `error.request` is an instance of XMLHttpRequest in the browser and an instance of
             // http.ClientRequest in node.js
-            console.error(error.request);
+            reject(new Error(error.request));
           } else {
             // Something happened in setting up the request that triggered an Error
-            console.error('Error', error.message);
+            reject(new Error(error.message));
           }
         });
     });
@@ -398,10 +398,10 @@ export class OpenVidu {
             // The request was made but no response was received
             // `error.request` is an instance of XMLHttpRequest in the browser and an instance of
             // http.ClientRequest in node.js
-            console.error(error.request);
+            reject(new Error(error.request));
           } else {
             // Something happened in setting up the request that triggered an Error
-            console.error('Error', error.message);
+            reject(new Error(error.message));
           }
         });
     });
@@ -479,11 +479,11 @@ export class OpenVidu {
             // The request was made but no response was received
             // `error.request` is an instance of XMLHttpRequest in the browser and an instance of
             // http.ClientRequest in node.js
-            console.error(error.request);
+            reject(new Error(error.request));
             reject(error);
           } else {
             // Something happened in setting up the request that triggered an Error
-            console.error('Error', error.message);
+            reject(new Error(error.message));
             reject(new Error(error.message));
           }
         });
@@ -649,10 +649,10 @@ export class OpenVidu {
             // The request was made but no response was received
             // `error.request` is an instance of XMLHttpRequest in the browser and an instance of
             // http.ClientRequest in node.js
-            console.error(error.request);
+            reject(new Error(error.request));
           } else {
             // Something happened in setting up the request that triggered an Error
-            console.error('Error', error.message);
+            reject(new Error(error.message));
           }
         });
     });
@@ -668,7 +668,6 @@ export class OpenVidu {
     try {
       url = new URL(this.hostname);
     } catch (error) {
-      console.error('URL format incorrect', error);
       throw new Error('URL format incorrect: ' + error);
     }
     this.host = url.protocol + '//' + url.host;

--- a/openvidu-node-client/src/Session.ts
+++ b/openvidu-node-client/src/Session.ts
@@ -511,11 +511,9 @@ export class Session {
                         // The request was made but no response was received
                         // `error.request` is an instance of XMLHttpRequest in the browser and an instance of
                         // http.ClientRequest in node.js
-                        console.error(error.request);
                         reject(new Error(error.request));
                     } else {
                         // Something happened in setting up the request that triggered an Error
-                        console.error('Error', error.message);
                         reject(new Error(error.message));
                     }
                 });
@@ -642,11 +640,9 @@ export class Session {
             // The request was made but no response was received
             // `error.request` is an instance of XMLHttpRequest in the browser and an instance of
             // http.ClientRequest in node.js
-            console.error(error.request);
             reject(new Error(error.request));
         } else {
             // Something happened in setting up the request that triggered an Error
-            console.error('Error', error.message);
             reject(new Error(error.message));
         }
     }


### PR DESCRIPTION
I was having difficulty reading my actual app logs because these console.error()s just dump the whole request on the console. I'm already handling the failure on a .catch() so writing to the console is just polluting.