### PR TITLE
openvidu-browser: Fixed bug when addTransceiver not available

### DIFF
--- a/openvidu-browser/src/OpenViduInternal/WebRtcPeer/WebRtcPeer.ts
+++ b/openvidu-browser/src/OpenViduInternal/WebRtcPeer/WebRtcPeer.ts
@@ -171,6 +171,13 @@ export class WebRtcPeer {
                 // Transceivers, and instead depend on the deprecated
                 // "offerToReceiveAudio" and "offerToReceiveVideo".
 
+                if (!!this.configuration.mediaStream) {
+                    for (const track of this.configuration.mediaStream.getTracks()) {
+                        // @ts-ignore - Compiler is too clever and thinks this branch will never execute.
+                        this.pc.addTrack(track, this.configuration.mediaStream);
+                    }
+                }
+
                 const hasAudio = this.configuration.mediaConstraints.audio;
                 const hasVideo = this.configuration.mediaConstraints.video;
 


### PR DESCRIPTION
After generateOffer() refactoring (commit e0f79e815e6f129741f5714ce426bb375bcce7e2) , the deprecated legacy method wasn't adding the meadstream tracks on peerConnection object as it used to do.