### PR TITLE
Coturn port conf

### DIFF
--- a/openvidu-browser/src/OpenVidu/Session.ts
+++ b/openvidu-browser/src/OpenVidu/Session.ts
@@ -1526,8 +1526,8 @@ export class Session extends EventDispatcher {
 
     private processJoinRoomResponse(opts: LocalConnectionOptions) {
         this.sessionId = opts.session;
-        if (opts.coturnIp != null && opts.turnUsername != null && opts.turnCredential != null) {
-            const turnUrl1 = 'turn:' + opts.coturnIp + ':3478';
+        if (opts.coturnIp != null && opts.coturnPort != null && opts.turnUsername != null && opts.turnCredential != null) {
+            const turnUrl1 = 'turn:' + opts.coturnIp + ':' + opts.coturnPort;
             this.openvidu.iceServers = [
                 { urls: [turnUrl1], username: opts.turnUsername, credential: opts.turnCredential }
             ];

--- a/openvidu-browser/src/OpenViduInternal/Interfaces/Private/LocalConnectionOptions.ts
+++ b/openvidu-browser/src/OpenViduInternal/Interfaces/Private/LocalConnectionOptions.ts
@@ -28,6 +28,7 @@ export interface LocalConnectionOptions {
     role: string;
     record: boolean;
     coturnIp: string;
+    coturnPort: string;
     turnUsername: string;
     turnCredential: string;
     version: string;

--- a/openvidu-client/src/main/java/io/openvidu/client/internal/ProtocolElements.java
+++ b/openvidu-client/src/main/java/io/openvidu/client/internal/ProtocolElements.java
@@ -162,6 +162,7 @@ public class ProtocolElements {
 	public static final String PARTICIPANTJOINED_RECORD_PARAM = "record";
 	public static final String PARTICIPANTJOINED_ROLE_PARAM = "role";
 	public static final String PARTICIPANTJOINED_COTURNIP_PARAM = "coturnIp";
+	public static final String PARTICIPANTJOINED_COTURNPORT_PARAM = "coturnPort";
 	public static final String PARTICIPANTJOINED_TURNUSERNAME_PARAM = "turnUsername";
 	public static final String PARTICIPANTJOINED_TURNCREDENTIAL_PARAM = "turnCredential";
 

--- a/openvidu-server/deployments/ce/docker-compose/docker-compose.yml
+++ b/openvidu-server/deployments/ce/docker-compose/docker-compose.yml
@@ -40,6 +40,7 @@ services:
             - COTURN_REDIS_IP=127.0.0.1
             - COTURN_REDIS_PASSWORD=${OPENVIDU_SECRET}
             - COTURN_IP=${COTURN_IP:-auto-ipv4}
+            - COTURN_PORT=${COTURN_PORT:-3478}
         logging:
             options:
                 max-size: "${DOCKER_LOGS_MAX_SIZE:-100M}"
@@ -84,11 +85,11 @@ services:
             - DB_PASSWORD=${OPENVIDU_SECRET}
         command:
             - --log-file=stdout
-            - --listening-port=3478
+            - --listening-port=${COTURN_PORT:-3478}
             - --fingerprint
             - --lt-cred-mech
-            - --min-port=57001
-            - --max-port=65535
+            - --min-port=${COTURN_MIN_PORT:-57001}
+            - --max-port=${COTURN_MIN_PORT:-65535}
             - --realm=openvidu
             - --verbose
         logging:

--- a/openvidu-server/deployments/enterprise/master-node/docker-compose.yml
+++ b/openvidu-server/deployments/enterprise/master-node/docker-compose.yml
@@ -45,6 +45,7 @@ services:
             - COTURN_REDIS_IP=127.0.0.1
             - COTURN_REDIS_PASSWORD=${OPENVIDU_SECRET}
             - COTURN_IP=${COTURN_IP:-auto-ipv4}
+            - COTURN_PORT=${COTURN_PORT:-3478}
             - OPENVIDU_PRO_CLUSTER=true
             - OPENVIDU_PRO_KIBANA_HOST=${OPENVIDU_PRO_KIBANA_HOST:-http://127.0.0.1/kibana}
             - OPENVIDU_PRO_ELASTICSEARCH_HOST=${OPENVIDU_PRO_ELASTICSEARCH_HOST:-http://127.0.0.1:9200}
@@ -105,11 +106,11 @@ services:
         command:
             - --log-file=stdout
             - --external-ip=$$(detect-external-ip)
-            - --listening-port=3478
+            - --listening-port=${COTURN_PORT:-3478}
             - --fingerprint
             - --lt-cred-mech
-            - --min-port=40000
-            - --max-port=65535
+            - --min-port=${COTURN_MIN_PORT:-40000}
+            - --max-port=${COTURN_MAX_PORT:-65535}
             - --realm=openvidu
             - --verbose
         logging:

--- a/openvidu-server/deployments/pro/docker-compose/openvidu-server-pro/docker-compose.yml
+++ b/openvidu-server/deployments/pro/docker-compose/openvidu-server-pro/docker-compose.yml
@@ -42,6 +42,7 @@ services:
             - COTURN_REDIS_IP=127.0.0.1
             - COTURN_REDIS_PASSWORD=${OPENVIDU_SECRET}
             - COTURN_IP=${COTURN_IP:-auto-ipv4}
+            - COTURN_PORT=${COTURN_PORT:-3478}
             - OPENVIDU_PRO_CLUSTER=true
             - OPENVIDU_PRO_KIBANA_HOST=${OPENVIDU_PRO_KIBANA_HOST:-http://127.0.0.1/kibana}
             - OPENVIDU_PRO_ELASTICSEARCH_HOST=${OPENVIDU_PRO_ELASTICSEARCH_HOST:-http://127.0.0.1:9200}
@@ -73,12 +74,12 @@ services:
             - DB_PASSWORD=${OPENVIDU_SECRET}
         command:
             - --log-file=stdout
-            - --external-ip=$$(detect-external-ip)
-            - --listening-port=3478
+            - --external-ip=${COTURN_IP:-auto-ipv4}
+            - --listening-port=${COTURN_PORT:-3478}
             - --fingerprint
             - --lt-cred-mech
-            - --min-port=40000
-            - --max-port=65535
+            - --min-port=${COTURN_MIN_PORT:-40000}
+            - --max-port=${COTURN_MAX_PORT:-65535}
             - --realm=openvidu
             - --verbose
         logging:

--- a/openvidu-server/src/main/java/io/openvidu/server/config/OpenviduConfig.java
+++ b/openvidu-server/src/main/java/io/openvidu/server/config/OpenviduConfig.java
@@ -159,6 +159,8 @@ public class OpenviduConfig {
 
 	private String coturnIp;
 
+	private int coturnPort;
+
 	private String coturnRedisIp;
 
 	// If true, coturn relay ips will come with the private IP of the machine
@@ -326,6 +328,10 @@ public class OpenviduConfig {
 
 	public String getCoturnIp() {
 		return this.coturnIp;
+	}
+
+	public int getCoturnPort() {
+		return this.coturnPort;
 	}
 
 	public RecordingNotification getOpenViduRecordingNotification() {
@@ -589,6 +595,8 @@ public class OpenviduConfig {
 
 		checkCoturnIp();
 
+		checkCoturnPort();
+
 		coturnRedisIp = asOptionalInetAddress("COTURN_REDIS_IP");
 
 		checkWebhook();
@@ -619,6 +627,14 @@ public class OpenviduConfig {
 			} catch (MalformedURLException e) {
 				log.error("Can't get Domain name from OpenVidu public Url: " + e.getMessage());
 			}
+		}
+	}
+
+	private void checkCoturnPort(){
+		String property = "COTURN_PORT";
+		coturnPort = this.asNonNegativeInteger(property);
+		if (coturnPort <= 0 || coturnPort > 65535){
+			log.warn("Non valid coturn port,  setting to default 3478");
 		}
 	}
 

--- a/openvidu-server/src/main/java/io/openvidu/server/core/SessionEventsHandler.java
+++ b/openvidu-server/src/main/java/io/openvidu/server/core/SessionEventsHandler.java
@@ -172,6 +172,7 @@ public class SessionEventsHandler {
 						participant.getToken().getRole().name());
 			}
 			result.addProperty(ProtocolElements.PARTICIPANTJOINED_COTURNIP_PARAM, openviduConfig.getCoturnIp());
+			result.addProperty(ProtocolElements.PARTICIPANTJOINED_COTURNPORT_PARAM, openviduConfig.getCoturnPort());
 			if (participant.getToken().getTurnCredentials() != null) {
 				result.addProperty(ProtocolElements.PARTICIPANTJOINED_TURNUSERNAME_PARAM,
 						participant.getToken().getTurnCredentials().getUsername());

--- a/openvidu-server/src/main/java/io/openvidu/server/coturn/BashCoturnCredentialsService.java
+++ b/openvidu-server/src/main/java/io/openvidu/server/coturn/BashCoturnCredentialsService.java
@@ -46,6 +46,7 @@ public class BashCoturnCredentialsService extends CoturnCredentialsService {
 				log.error("No COTURN server will be automatically configured for clients");
 			} else {
 				log.info("COTURN IP: " + this.openviduConfig.getCoturnIp());
+				log.info("COTURN PORT: " + this.openviduConfig.getCoturnPort());
 				log.info("COTURN Redis DB accessible with string " + this.coturnDatabaseString);
 				log.info("Cleaning COTURN DB...");
 				if (response.contains("log file opened")) {

--- a/openvidu-server/src/main/java/io/openvidu/server/kurento/endpoint/MediaEndpoint.java
+++ b/openvidu-server/src/main/java/io/openvidu/server/kurento/endpoint/MediaEndpoint.java
@@ -303,7 +303,7 @@ public abstract class MediaEndpoint {
 					if (openviduConfig.getCoturnIp() != null && !openviduConfig.getCoturnIp().isEmpty()
 							&& openviduConfig.isTurnadminAvailable()) {
 						webEndpoint.setStunServerAddress(openviduConfig.getCoturnIp());
-						webEndpoint.setStunServerPort(3478);
+						webEndpoint.setStunServerPort(openviduConfig.getCoturnPort());
 					}
 
 					endpointLatch.countDown();


### PR DESCRIPTION
This changes allow the coturn to run in a different port than the default. 
The changes affects to: 
  - the information that OpenVidu server returns for a session (adding to the turnIP the turnPort) 
  - the environment variables that can be set COTUR_PORT is added 
  - the openviud-browser needs the coturn port to add the turn server.
  
 When coturn Port isn't set OpenVidu server will work with the default coturn Port (defined in the docker-compose.yml as default)
 
To test the changes: 
- Default behaviour launch with default values and check connection through the COTURN
- custom COTURN PORT: add in the .env COTURN_PORT value and check connection through COTURN. You would see (i) the COTURN is listening on the custom port, (ii) the openVidu server is connecting to the COTURN through the custom port and (iii) is communicating properly to the clients.  