### PR TITLE
openvidu-server: add MKV recording profile as part of MediaServer enum

### DIFF
--- a/openvidu-server/src/main/java/io/openvidu/server/core/MediaServer.java
+++ b/openvidu-server/src/main/java/io/openvidu/server/core/MediaServer.java
@@ -1,7 +1,29 @@
 package io.openvidu.server.core;
 
+import org.kurento.client.MediaProfileSpecType;
+
 public enum MediaServer {
+	kurento(MediaProfileSpecType.WEBM), mediasoup(MediaProfileSpecType.MKV);
 
-	kurento, mediasoup
+	private final MediaProfileSpecType recordingProfile;
 
+	MediaServer(MediaProfileSpecType recordingProfile) {
+		this.recordingProfile = recordingProfile;
+	}
+
+	public MediaProfileSpecType getRecordingProfile() {
+		return recordingProfile;
+	}
+
+	public MediaProfileSpecType getRecordingProfileAudioOnly() {
+		return MediaProfileSpecType.valueOf(recordingProfile.name() + "_AUDIO_ONLY");
+	}
+
+	public MediaProfileSpecType getRecordingProfileVideoOnly() {
+		return MediaProfileSpecType.valueOf(recordingProfile.name() + "_VIDEO_ONLY");
+	}
+
+	public String getRecordingFileExtension() {
+		return "." + recordingProfile.name().toLowerCase();
+	}
 }

--- a/openvidu-server/src/main/java/io/openvidu/server/recording/RecorderEndpointWrapper.java
+++ b/openvidu-server/src/main/java/io/openvidu/server/recording/RecorderEndpointWrapper.java
@@ -30,6 +30,7 @@ public class RecorderEndpointWrapper {
 	private RecorderEndpoint recorder;
 	private KurentoParticipant kParticipant;
 	private String name;
+	private String fileExtension;
 	private String connectionId;
 	private String recordingId;
 	private String streamId;
@@ -44,8 +45,9 @@ public class RecorderEndpointWrapper {
 	private long size;
 
 	public RecorderEndpointWrapper(RecorderEndpoint recorder, KurentoParticipant kParticipant, String recordingId,
-			String name) {
+			String name, String fileExtension) {
 		this.name = name;
+		this.fileExtension = fileExtension;
 		this.recorder = recorder;
 		this.kParticipant = kParticipant;
 		this.recordingId = recordingId;
@@ -58,10 +60,11 @@ public class RecorderEndpointWrapper {
 		this.typeOfVideo = kParticipant.getPublisher().getMediaOptions().getTypeOfVideo();
 	}
 
-	public RecorderEndpointWrapper(JsonObject json) {
+	public RecorderEndpointWrapper(JsonObject json, String fileExtension) {
 		String nameAux = json.get("name").getAsString();
 		// If the name includes the extension, remove it
-		this.name = StringUtils.removeEnd(nameAux, RecordingService.INDIVIDUAL_RECORDING_EXTENSION);
+		this.name = StringUtils.removeEnd(nameAux, fileExtension);
+		this.fileExtension = fileExtension;
 		this.connectionId = json.get("connectionId").getAsString();
 		this.streamId = json.get("streamId").getAsString();
 		this.clientData = (json.has("clientData") && !json.get("clientData").isJsonNull())
@@ -91,7 +94,7 @@ public class RecorderEndpointWrapper {
 	}
 
 	public String getNameWithExtension() {
-		return this.name + RecordingService.INDIVIDUAL_RECORDING_EXTENSION;
+		return this.name + fileExtension;
 	}
 
 	public String getConnectionId() {

--- a/openvidu-server/src/main/java/io/openvidu/server/recording/service/RecordingManager.java
+++ b/openvidu-server/src/main/java/io/openvidu/server/recording/service/RecordingManager.java
@@ -764,7 +764,7 @@ public class RecordingManager {
 
 		final String testFolderPath = openviduRecordingPath + "/TEST_RECORDING_PATH_" + System.currentTimeMillis();
 		final String testFilePath = testFolderPath + "/TEST_RECORDING_PATH"
-				+ RecordingService.INDIVIDUAL_RECORDING_EXTENSION;
+				+ openviduConfig.getMediaServer().getRecordingFileExtension();
 
 		// Check Kurento Media Server write permissions in recording path
 		if (this.kmsManager.getKmss().isEmpty()) {

--- a/openvidu-server/src/main/java/io/openvidu/server/recording/service/RecordingService.java
+++ b/openvidu-server/src/main/java/io/openvidu/server/recording/service/RecordingService.java
@@ -54,9 +54,9 @@ public abstract class RecordingService {
 
 	public final static String RECORDING_ENTITY_FILE = ".recording.";
 	public final static String COMPOSED_RECORDING_EXTENSION = ".mp4";
+	public final static String COMPOSED_RECORDING_AUDIO_ONLY_EXTENSION = ".webm";
 	public final static String COMPOSED_THUMBNAIL_EXTENSION = ".jpg";
 	public final static String COMPOSED_INFO_FILE_EXTENSION = ".info";
-	public final static String INDIVIDUAL_RECORDING_EXTENSION = ".webm";
 	public final static String INDIVIDUAL_STREAM_METADATA_FILE = ".stream.";
 	public final static String INDIVIDUAL_RECORDING_COMPRESSED_EXTENSION = ".zip";
 


### PR DESCRIPTION
Uses the MediaServer enum to contain information that is specific about
each particular media server. Specifically,

* kurento must record with the WEBM profile and ".webm" file extension
* mediasoup must record with the MKV profile and ".mkv" file extension

Integrating this as part of the global Openvidu config object makes it
trivial to replace the static or hardcoded lines with others that simply
obtain the data from the current media server mode in use.