### PR TITLE
openvidu-browser: improve typings for session event dispatcher methods

### DIFF
--- a/openvidu-browser/src/OpenVidu/Session.ts
+++ b/openvidu-browser/src/OpenVidu/Session.ts
@@ -57,6 +57,25 @@ const logger: OpenViduLogger = OpenViduLogger.getInstance();
  */
 let platform: PlatformUtils;
 
+export interface SessionEventMap {
+    connectionCreated: ConnectionEvent
+    connectionDestroyed: ConnectionEvent
+    connectionPropertyChanged: ConnectionPropertyChangedEvent
+    sessionDisconnected: SessionDisconnectedEvent
+    streamCreated: StreamEvent
+    streamDestroyed: StreamEvent
+    streamPropertyChanged: StreamPropertyChangedEvent
+    publisherStartSpeaking: PublisherSpeakingEvent
+    publisherStopSpeaking: PublisherSpeakingEvent
+    signal: SignalEvent
+    recordingStarted: RecordingEvent
+    recordingStopped: RecordingEvent
+    networkQualityLevelChanged: NetworkQualityLevelChangedEvent
+    reconnecting: never
+    reconnected: never
+    exception: ExceptionEvent
+}
+
 /**
  * Represents a video call. It can also be seen as a videoconference room where multiple users can connect.
  * Participants who publish their videos to a session can be seen by the rest of users connected to that specific session.
@@ -640,7 +659,7 @@ export class Session extends EventDispatcher {
     /**
      * See [[EventDispatcher.on]]
      */
-    on(type: string, handler: (event: SessionDisconnectedEvent | SignalEvent | StreamEvent | ConnectionEvent | PublisherSpeakingEvent | RecordingEvent | NetworkQualityLevelChangedEvent | ExceptionEvent) => void): EventDispatcher {
+     on<K extends keyof SessionEventMap>(type: K, handler: (event: SessionEventMap[K]) => void): this {
 
         super.onAux(type, "Event '" + type + "' triggered by 'Session'", handler);
 
@@ -676,7 +695,7 @@ export class Session extends EventDispatcher {
     /**
      * See [[EventDispatcher.once]]
      */
-    once(type: string, handler: (event: SessionDisconnectedEvent | SignalEvent | StreamEvent | ConnectionEvent | PublisherSpeakingEvent | RecordingEvent | NetworkQualityLevelChangedEvent | ExceptionEvent) => void): Session {
+    once<K extends keyof SessionEventMap>(type: K, handler: (event: SessionEventMap[K]) => void): this {
 
         super.onceAux(type, "Event '" + type + "' triggered once by 'Session'", handler);
 
@@ -712,7 +731,7 @@ export class Session extends EventDispatcher {
     /**
      * See [[EventDispatcher.off]]
      */
-    off(type: string, handler?: (event: SessionDisconnectedEvent | SignalEvent | StreamEvent | ConnectionEvent | PublisherSpeakingEvent | RecordingEvent | NetworkQualityLevelChangedEvent | ExceptionEvent) => void): Session {
+    off<K extends keyof SessionEventMap>(type: K, handler: (event: SessionEventMap[K]) => void): this {
 
         super.off(type, handler);
 


### PR DESCRIPTION
This helps typescript to know the expected event type and also IDEs to suggest possible event names.

<img width="551" alt="Screen Shot 2021-12-27 at 17 25 31" src="https://user-images.githubusercontent.com/15037839/147476428-64dac13d-f789-4055-844d-c61b52892ed9.png">

<img width="318" alt="Screen Shot 2021-12-27 at 17 26 19" src="https://user-images.githubusercontent.com/15037839/147476440-bd505026-64b4-44a9-b434-4f534f7285e2.png">


Borrowed from:
https://github.com/microsoft/TypeScript/blob/ef9fd97e4dbcc0a26fa5bac7007e8bfa594ccccd/lib/lib.dom.d.ts#L4689-L4692


If the PR gets accepted we can do the same for other event dispatchers