### PR TITLE
Check for outboundStreamOpts before accessing it

### DIFF
--- a/openvidu-browser/src/OpenVidu/Stream.ts
+++ b/openvidu-browser/src/OpenVidu/Stream.ts
@@ -548,12 +548,15 @@ export class Stream {
      * @hidden
      */
     isSendScreen(): boolean {
+        if (!this.outboundStreamOpts) {
+            return false;
+        }
         let screen = this.outboundStreamOpts.publisherProperties.videoSource === 'screen';
         if (platform.isElectron()) {
             screen = typeof this.outboundStreamOpts.publisherProperties.videoSource === 'string' &&
                 this.outboundStreamOpts.publisherProperties.videoSource.startsWith('screen:');
         }
-        return !!this.outboundStreamOpts && screen;
+        return screen;
     }
 
     /**


### PR DESCRIPTION
This method should be the same as the others in regards to checking for valid property.
It seems the extra logic for `isElectron` evaded the correct checking when calling from an incoming stream.

Error reported:
TypeError: Cannot read properties of undefined (reading 'publisherProperties')
```