### PR TITLE
Ensure video element mirroring is removed

### DIFF
--- a/openvidu-browser/src/OpenVidu/StreamManager.ts
+++ b/openvidu-browser/src/OpenVidu/StreamManager.ts
@@ -414,7 +414,12 @@ export class StreamManager extends EventDispatcher {
             }
         }
 
-        if (!this.remote && !this.stream.displayMyRemote()) {
+        if (this.remote) {
+          // Do not mirror remote video.
+          // Remove the mirror if this video was currently associated with a local mirrored video.
+          this.removeMirrorVideo(video);
+        }
+        else if (!this.stream.displayMyRemote()) {
             video.muted = true;
             if (video.style.transform === 'rotateY(180deg)' && !this.stream.outboundStreamOpts.publisherProperties.mirror) {
                 // If the video was already rotated and now is set to not mirror


### PR DESCRIPTION
When reusing a video element between a local stream with mirroring, and a remote stream with no mirroring, the element's mirror transform was not getting removed.