### PR TITLE
Change to new API methods for Kurento release 6.18.0

### DIFF
--- a/openvidu-server/src/main/java/io/openvidu/server/kurento/core/KurentoParticipantEndpointConfig.java
+++ b/openvidu-server/src/main/java/io/openvidu/server/kurento/core/KurentoParticipantEndpointConfig.java
@@ -77,8 +77,8 @@ public class KurentoParticipantEndpointConfig {
 				log.info(msg);
 			});
 
-			finalEndpoint.addIceComponentStateChangeListener(event -> {
-				String msg = "KMS event [IceComponentStateChange]: -> endpoint: " + endpoint.getEndpointName() + " ("
+			finalEndpoint.addIceComponentStateChangedListener(event -> {
+				String msg = "KMS event [IceComponentStateChanged]: -> endpoint: " + endpoint.getEndpointName() + " ("
 						+ typeOfEndpoint + ") | state: " + event.getState().name() + " | componentId: "
 						+ event.getComponentId() + " | streamId: " + event.getStreamId() + " | timestamp: "
 						+ event.getTimestampMillis();
@@ -90,8 +90,8 @@ public class KurentoParticipantEndpointConfig {
 				log.info(msg);
 			});
 
-			finalEndpoint.addDataChannelOpenListener(event -> {
-				String msg = "KMS event [DataChannelOpenEvent]: -> endpoint: " + endpoint.getEndpointName() + " ("
+			finalEndpoint.addDataChannelOpenedListener(event -> {
+				String msg = "KMS event [DataChannelOpenedEvent]: -> endpoint: " + endpoint.getEndpointName() + " ("
 						+ typeOfEndpoint + ") | channelId: " + event.getChannelId() + " | timestamp: "
 						+ event.getTimestampMillis();
 				KmsEvent kmsEvent = new KmsEvent(event, endpoint.getOwner(), endpoint.getEndpointName(),
@@ -102,8 +102,8 @@ public class KurentoParticipantEndpointConfig {
 				log.info(msg);
 			});
 
-			finalEndpoint.addDataChannelCloseListener(event -> {
-				String msg = "KMS event [DataChannelCloseEvent]: -> endpoint: " + endpoint.getEndpointName() + " ("
+			finalEndpoint.addDataChannelClosedListener(event -> {
+				String msg = "KMS event [DataChannelClosedEvent]: -> endpoint: " + endpoint.getEndpointName() + " ("
 						+ typeOfEndpoint + ") | channelId: " + event.getChannelId() + " | timestamp: "
 						+ event.getTimestampMillis();
 				KmsEvent kmsEvent = new KmsEvent(event, endpoint.getOwner(), endpoint.getEndpointName(),
@@ -180,8 +180,8 @@ public class KurentoParticipantEndpointConfig {
 		// Endpoint events
 		final Endpoint finalEndpoint = endpoint.getEndpoint();
 
-		finalEndpoint.addMediaFlowInStateChangeListener(event -> {
-			String msg = "KMS event [MediaFlowInStateChange] -> endpoint: " + endpoint.getEndpointName() + " ("
+		finalEndpoint.addMediaFlowInStateChangedListener(event -> {
+			String msg = "KMS event [MediaFlowInStateChanged] -> endpoint: " + endpoint.getEndpointName() + " ("
 					+ typeOfEndpoint + ") | state: " + event.getState() + " | pad: " + event.getPadName()
 					+ " | mediaType: " + event.getMediaType() + " | timestamp: " + event.getTimestampMillis();
 			KmsEvent kmsEvent = new KmsMediaEvent(event, endpoint.getOwner(), endpoint.getEndpointName(),
@@ -192,8 +192,8 @@ public class KurentoParticipantEndpointConfig {
 			log.info(msg);
 		});
 
-		finalEndpoint.addMediaFlowOutStateChangeListener(event -> {
-			String msg = "KMS event [MediaFlowOutStateChange] -> endpoint: " + endpoint.getEndpointName() + " ("
+		finalEndpoint.addMediaFlowOutStateChangedListener(event -> {
+			String msg = "KMS event [MediaFlowOutStateChanged] -> endpoint: " + endpoint.getEndpointName() + " ("
 					+ typeOfEndpoint + ") | state: " + event.getState() + " | pad: " + event.getPadName()
 					+ " | mediaType: " + event.getMediaType() + " | timestamp: " + event.getTimestampMillis();
 			KmsEvent kmsEvent = new KmsMediaEvent(event, endpoint.getOwner(), endpoint.getEndpointName(),
@@ -216,8 +216,8 @@ public class KurentoParticipantEndpointConfig {
 			log.error(msg);
 		});
 
-		finalEndpoint.addMediaTranscodingStateChangeListener(event -> {
-			String msg = "KMS event [MediaTranscodingStateChange]: -> endpoint: " + endpoint.getEndpointName() + " ("
+		finalEndpoint.addMediaTranscodingStateChangedListener(event -> {
+			String msg = "KMS event [MediaTranscodingStateChanged]: -> endpoint: " + endpoint.getEndpointName() + " ("
 					+ typeOfEndpoint + ") | state: " + event.getState().name() + " | mediaType: " + event.getMediaType()
 					+ " | binName: " + event.getBinName() + " | timestamp: " + event.getTimestampMillis();
 			KmsEvent kmsEvent = new KmsMediaEvent(event, endpoint.getOwner(), endpoint.getEndpointName(),

--- a/openvidu-server/src/main/java/io/openvidu/server/kurento/endpoint/MediaEndpoint.java
+++ b/openvidu-server/src/main/java/io/openvidu/server/kurento/endpoint/MediaEndpoint.java
@@ -556,11 +556,11 @@ public abstract class MediaEndpoint {
 	 * the remote User Agent as a notification using the messaging capabilities of
 	 * the {@link Participant}.
 	 *
-	 * @see WebRtcEndpoint#addOnIceCandidateListener(org.kurento.client.EventListener)
+	 * @see WebRtcEndpoint#addIceCandidateFoundListener(org.kurento.client.EventListener)
 	 * @see Participant#sendIceCandidate(String, IceCandidate)
 	 * @throws OpenViduException if thrown, unable to register the listener
 	 */
-	protected void registerOnIceCandidateEventListener(String senderPublicId) throws OpenViduException {
+	protected void registerIceCandidateFoundEventListener(String senderPublicId) throws OpenViduException {
 		if (!this.isWeb()) {
 			return;
 		}

--- a/openvidu-server/src/main/java/io/openvidu/server/kurento/endpoint/PublisherEndpoint.java
+++ b/openvidu-server/src/main/java/io/openvidu/server/kurento/endpoint/PublisherEndpoint.java
@@ -84,7 +84,7 @@ public class PublisherEndpoint extends MediaEndpoint {
 	 * This lock protects the following method with read lock:
 	 * KurentoParticipant#receiveMediaFrom. It uses tryLock, immediately failing if
 	 * written locked
-	 * 
+	 *
 	 * Lock is written-locked upon KurentoParticipant#releasePublisherEndpoint and
 	 * KurentoParticipant#cancelReceivingMedia
 	 */
@@ -189,7 +189,7 @@ public class PublisherEndpoint extends MediaEndpoint {
 	 */
 	public synchronized String publish(String sdpOffer, boolean doLoopback) {
 		String sdpResponse = processOffer(sdpOffer);
-		registerOnIceCandidateEventListener(this.getOwner().getParticipantPublicId());
+		registerIceCandidateFoundEventListener(this.getOwner().getParticipantPublicId());
 		if (doLoopback) {
 			connect(this.getEndpoint(), false);
 		} else {

--- a/openvidu-server/src/main/java/io/openvidu/server/kurento/endpoint/SubscriberEndpoint.java
+++ b/openvidu-server/src/main/java/io/openvidu/server/kurento/endpoint/SubscriberEndpoint.java
@@ -48,7 +48,7 @@ public class SubscriberEndpoint extends MediaEndpoint {
 	}
 
 	public synchronized String prepareSubscription(PublisherEndpoint publisher) {
-		registerOnIceCandidateEventListener(publisher.getOwner().getParticipantPublicId());
+		registerIceCandidateFoundEventListener(publisher.getOwner().getParticipantPublicId());
 		publisher.connect(this.getEndpoint(), true);
 		this.createdAt = System.currentTimeMillis();
 		this.publisherStreamId = publisher.getStreamId();
@@ -65,7 +65,7 @@ public class SubscriberEndpoint extends MediaEndpoint {
 	public synchronized String subscribe(String sdpString, PublisherEndpoint publisher) {
 		if (this.publisherStreamId == null) {
 			// Client initiated negotiation
-			registerOnIceCandidateEventListener(publisher.getOwner().getParticipantPublicId());
+			registerIceCandidateFoundEventListener(publisher.getOwner().getParticipantPublicId());
 			this.createdAt = System.currentTimeMillis();
 			String realSdpAnswer = processOffer(sdpString);
 			gatherCandidates();

--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
 	</developers>
 
 	<properties>
-		<version.kurento>6.16.5</version.kurento>
+		<version.kurento>6.18.0-SNAPSHOT</version.kurento>
 		<version.spring-boot>2.3.12.RELEASE</version.spring-boot>
 		<version.junit>4.13.1</version.junit>
 		<version.junit.jupiter>5.8.1</version.junit.jupiter>


### PR DESCRIPTION
Change to new API methods for Kurento release 6.18.0

The old names become deprecated since Kurento 6.18, and will be definitely removed in Kurento 7.0

* Old: MediaFlowOutStateChange
  New: MediaFlowOutStateChanged

* Old: MediaFlowInStateChange
  New: MediaFlowInStateChanged

* Old: MediaTranscodingStateChange
  New: MediaTranscodingStateChanged

* Old: OnIceCandidate
  New: IceCandidateFound

* Old: OnIceGatheringDone
  New: IceGatheringDone

* Old: OnIceComponentStateChanged, IceComponentStateChanges
  New: IceComponentStateChanged

* Old: OnDataChannelOpened, DataChannelOpens
  New: DataChannelOpened

* Old: OnDataChannelClosed, DataChannelClose
  New: DataChannelClosed
