### PR TITLE
Improvements for deployment script "logs" command

### DIFF
--- a/openvidu-server/deployments/ce/docker-compose/openvidu
+++ b/openvidu-server/deployments/ce/docker-compose/openvidu
@@ -231,7 +231,7 @@ kurento_logs() {
 case $1 in
   start)
     docker-compose up -d
-    docker-compose logs -f openvidu-server
+    docker-compose logs -f --tail 10 openvidu-server
     ;;
 
   stop)
@@ -241,13 +241,13 @@ case $1 in
   restart)
     docker-compose down
     docker-compose up -d
-    docker-compose logs -f openvidu-server
+    docker-compose logs -f --tail 10 openvidu-server
     ;;
 
   logs)
     case $2 in
       "-f")
-        docker-compose logs -f openvidu-server
+        docker-compose logs -f --tail 10 openvidu-server
         ;;
       *)
         docker-compose logs openvidu-server

--- a/openvidu-server/deployments/ce/docker-compose/openvidu
+++ b/openvidu-server/deployments/ce/docker-compose/openvidu
@@ -245,8 +245,8 @@ case $1 in
     ;;
 
   logs)
-    case $2 in
-      "-f")
+    case "${2-}" in
+      --follow|-f)
         docker-compose logs -f --tail 10 openvidu-server
         ;;
       *)

--- a/openvidu-server/deployments/enterprise/master-node/openvidu
+++ b/openvidu-server/deployments/enterprise/master-node/openvidu
@@ -237,7 +237,7 @@ case $1 in
   start)
     start_openvidu
     if [[ "${FOLLOW_OPENVIDU_LOGS}" == "true" ]]; then
-      docker-compose logs -f openvidu-server
+      docker-compose logs -f --tail 10 openvidu-server
     fi
     ;;
 
@@ -249,12 +249,12 @@ case $1 in
     docker-compose down
     start_openvidu
     if [[ "${FOLLOW_OPENVIDU_LOGS}" == "true" ]]; then
-      docker-compose logs -f openvidu-server
+      docker-compose logs -f --tail 10 openvidu-server
     fi
     ;;
 
   logs)
-    docker-compose logs -f openvidu-server
+    docker-compose logs -f --tail 10 openvidu-server
     ;;
 
   upgrade)

--- a/openvidu-server/deployments/enterprise/master-node/openvidu
+++ b/openvidu-server/deployments/enterprise/master-node/openvidu
@@ -254,7 +254,14 @@ case $1 in
     ;;
 
   logs)
-    docker-compose logs -f --tail 10 openvidu-server
+    case "${2-}" in
+      --follow|-f)
+        docker-compose logs -f --tail 10 openvidu-server
+        ;;
+      *)
+        docker-compose logs openvidu-server
+        ;;
+    esac
     ;;
 
   upgrade)

--- a/openvidu-server/deployments/pro/docker-compose/media-node/media_node
+++ b/openvidu-server/deployments/pro/docker-compose/media-node/media_node
@@ -243,7 +243,7 @@ case $1 in
 
   start)
     docker-compose up -d
-    docker-compose logs -f media-node-controller
+    docker-compose logs -f --tail 10 media-node-controller
     ;;
 
   stop)
@@ -255,13 +255,13 @@ case $1 in
     docker-compose down
     stop_containers
     docker-compose up -d
-    docker-compose logs -f media-node-controller
+    docker-compose logs -f --tail 10 media-node-controller
     ;;
 
   logs)
     case $2 in
       "-f")
-        docker-compose logs -f media-node-controller
+        docker-compose logs -f --tail 10 media-node-controller
         ;;
       *)
         docker-compose logs media-node-controller

--- a/openvidu-server/deployments/pro/docker-compose/media-node/media_node
+++ b/openvidu-server/deployments/pro/docker-compose/media-node/media_node
@@ -259,8 +259,8 @@ case $1 in
     ;;
 
   logs)
-    case $2 in
-      "-f")
+    case "${2-}" in
+      --follow|-f)
         docker-compose logs -f --tail 10 media-node-controller
         ;;
       *)

--- a/openvidu-server/deployments/pro/docker-compose/openvidu-server-pro/openvidu
+++ b/openvidu-server/deployments/pro/docker-compose/openvidu-server-pro/openvidu
@@ -257,7 +257,7 @@ case $1 in
   start)
     start_openvidu
     if [[ "${FOLLOW_OPENVIDU_LOGS}" == "true" ]]; then
-      docker-compose logs -f openvidu-server
+      docker-compose logs -f --tail 10 openvidu-server
     fi
     ;;
 
@@ -269,12 +269,12 @@ case $1 in
     docker-compose down
     start_openvidu
     if [[ "${FOLLOW_OPENVIDU_LOGS}" == "true" ]]; then
-      docker-compose logs -f openvidu-server
+      docker-compose logs -f --tail 10 openvidu-server
     fi
     ;;
 
   logs)
-    docker-compose logs -f openvidu-server
+    docker-compose logs -f --tail 10 openvidu-server
     ;;
 
   upgrade)

--- a/openvidu-server/deployments/pro/docker-compose/openvidu-server-pro/openvidu
+++ b/openvidu-server/deployments/pro/docker-compose/openvidu-server-pro/openvidu
@@ -274,7 +274,14 @@ case $1 in
     ;;
 
   logs)
-    docker-compose logs -f --tail 10 openvidu-server
+    case "${2-}" in
+      --follow|-f)
+        docker-compose logs -f --tail 10 openvidu-server
+        ;;
+      *)
+        docker-compose logs openvidu-server
+        ;;
+    esac
     ;;
 
   upgrade)


### PR DESCRIPTION
# Use "--tail 10" to follow logs

docker-compose uses "--tail all" by default, which prints the complete
logs before starting to follow new lines. This becomes a problem when
the service has been running for a lot of time and there are thousand of
lines.

Use "--tail 10" to mimic the behavior of the "tail" program, which shows
the latest 10 lines by default.


# Allow users to print whole logs or just follow them

Users can call the script with "-f" or "--follow" in order to follow the
latest lines (like with system tool "tail -f"), of not provide this
argument to obtain the whole contents of the logs.