### PR TITLE
Audio is not working properly when camera is muted

### DIFF
--- a/openvidu-browser/src/OpenVidu/Session.ts
+++ b/openvidu-browser/src/OpenVidu/Session.ts
@@ -992,6 +992,10 @@ export class Session extends EventDispatcher {
                         oldValue = stream.videoActive;
                         event.newValue = event.newValue === 'true';
                         stream.videoActive = event.newValue;
+                        const videoTrack = stream.getMediaStream().getVideoTracks()[0];
+                        if(!videoTrack.enabled && stream.videoActive){
+                            videoTrack.enabled = true;
+                        }
                         break;
                     case 'videoTrack':
                         event.newValue = JSON.parse(event.newValue);

--- a/openvidu-browser/src/OpenVidu/Stream.ts
+++ b/openvidu-browser/src/OpenVidu/Stream.ts
@@ -1481,7 +1481,7 @@ export class Stream {
                     this.mediaStream.getAudioTracks()[0].enabled = enabled;
                 }
                 if (!!this.mediaStream.getVideoTracks()[0]) {
-                    const enabled = reconnect ? this.videoActive : !!(this.streamManager as Subscriber).properties.subscribeToVideo;
+                    const enabled = reconnect ? this.videoActive : !!this.videoActive && !!(this.streamManager as Subscriber).properties.subscribeToVideo;
                     this.mediaStream.getVideoTracks()[0].enabled = enabled;
                 }
             }


### PR DESCRIPTION
If a MediaStream is published with video track stopped  and a standard audio track, the video was not playing because the video track of subscriber was enabled. This track must be disabled for allowing play the video. 
Issue reference: https://openvidu.discourse.group/t/microphone-doesnt-work-correctly-on-web-from-a-mobile-device/4514

Steps for reproducing the problem:
1. Connect a standard user to a session
2. In other device, initialice a publisher
3. Mute the camera publisher using publishVideo method releasing the video device (it applies track.stop()).
4. Connect to same session as other participant
5.  The first particpant is not receiving the second participant audio.
