### PR TITLE
Tolerate inaccessible localStorage

### DIFF
--- a/openvidu-browser/src/OpenViduInternal/WebRtcStats/WebRtcStats.ts
+++ b/openvidu-browser/src/OpenViduInternal/WebRtcStats/WebRtcStats.ts
@@ -121,7 +121,13 @@ export class WebRtcStats {
     }
 
     public initWebRtcStats(): void {
-        const webrtcObj = localStorage.getItem(this.STATS_ITEM_NAME);
+        let webrtcObj = null;
+        // When cross-site (aka third-party) cookies are blocked by the browser,
+        // accessing localStorage in a third-party iframe throws a DOMException.
+        try {
+            webrtcObj = localStorage.getItem(this.STATS_ITEM_NAME);
+        }
+        catch(e){}
 
         if (!!webrtcObj) {
             this.webRtcStatsEnabled = true;


### PR DESCRIPTION
### Fixes the issue
With cross-site (aka third-party) cookies are blocked , media streams will fail to play in a cross-origin iframe. 
E.g. Chrome's Incognito mode, or Chrome and Firefox with Settings-> Privacy & Security -> Cookies and other site data -> Block third-party-cookies.

### Reason
`WebRtcStats::initWebRtcStats()` throws a `DOMException`

When cross-site (aka third-party) cookies are blocked by the browser, accessing localStorage in a third-party iframe throws a DOMException.

### Fix
When reading from `localStorage` treat (security) exceptions like absent values.
Apart from reading from `localStorage` in `WebRtcStats::initWebRtcStats()`, `openvidu-browser` does not access localStorage or sessionStorage anywhere else.