### PR TITLE
openvidu-java-client : Remove redundant getSessionId() call 

### DIFF
--- a/openvidu-java-client/src/main/java/io/openvidu/java/client/Session.java
+++ b/openvidu-java-client/src/main/java/io/openvidu/java/client/Session.java
@@ -119,10 +119,6 @@ public class Session {
 	 */
 	@Deprecated
 	public String generateToken(TokenOptions tokenOptions) throws OpenViduJavaClientException, OpenViduHttpException {
-		if (!this.hasSessionId()) {
-			this.getSessionId();
-		}
-
 		final HttpClientResponseHandler<String> responseHandler = new HttpClientResponseHandler<String>() {
 			@Override
 			public String handleResponse(final ClassicHttpResponse response) throws IOException, HttpException {

--- a/openvidu-java-client/src/main/java/io/openvidu/java/client/Session.java
+++ b/openvidu-java-client/src/main/java/io/openvidu/java/client/Session.java
@@ -182,10 +182,6 @@ public class Session {
 	 */
 	public Connection createConnection(ConnectionProperties connectionProperties)
 			throws OpenViduJavaClientException, OpenViduHttpException {
-		if (!this.hasSessionId()) {
-			this.getSessionId();
-		}
-
 		final HttpClientResponseHandler<Connection> responseHandler = new HttpClientResponseHandler<Connection>() {
 			@Override
 			public Connection handleResponse(final ClassicHttpResponse response) throws IOException, HttpException {


### PR DESCRIPTION

The `if (!this.hasSessionId())' check followed by the 'this.getSessionId();` call is redundant and does not affect the behavior of the code. Removing this unnecessary call for improved code clarity.