### PR TITLE
chore: update OpenVidu/actions to v1.0.13

### DIFF
--- a/.github/workflows/openvidu-components-angular-tests.yml
+++ b/.github/workflows/openvidu-components-angular-tests.yml
@@ -107,15 +107,15 @@ jobs:
             docker run --network=host -d -p 4444:4444 ${{ env.CHROME_IMAGE }}
           fi
       - name: Run openvidu-local-deployment
-        uses: OpenVidu/actions/start-openvidu-local-deployment@9a2f61e73052475bd4572ce2f3a574476a37eae5 # v1.0.8
+        uses: OpenVidu/actions/start-openvidu-local-deployment@463dfe08b1b31721b73459a02417eae59198fc93 # v1.0.13
       - name: Start OpenVidu Call backend
-        uses: OpenVidu/actions/start-openvidu-call@9a2f61e73052475bd4572ce2f3a574476a37eae5 # v1.0.8
+        uses: OpenVidu/actions/start-openvidu-call@463dfe08b1b31721b73459a02417eae59198fc93 # v1.0.13
       - name: Build and Serve openvidu-components-angular Testapp
-        uses: OpenVidu/actions/start-openvidu-components-testapp@9a2f61e73052475bd4572ce2f3a574476a37eae5 # v1.0.8
+        uses: OpenVidu/actions/start-openvidu-components-testapp@463dfe08b1b31721b73459a02417eae59198fc93 # v1.0.13
       - name: Run Tests
         env:
           LAUNCH_MODE: CI
         run: npm run ${{ matrix.script }} --prefix openvidu-components-angular
       - name: Cleanup
         if: always()
-        uses: OpenVidu/actions/cleanup@9a2f61e73052475bd4572ce2f3a574476a37eae5 # v1.0.8
+        uses: OpenVidu/actions/cleanup@463dfe08b1b31721b73459a02417eae59198fc93 # v1.0.13

--- a/.github/workflows/openvidu-integration-tests.yml
+++ b/.github/workflows/openvidu-integration-tests.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Configure OpenVidu Local Deployment
-        uses: OpenVidu/actions/start-openvidu-local-deployment@9a2f61e73052475bd4572ce2f3a574476a37eae5 # v1.0.8
+        uses: OpenVidu/actions/start-openvidu-local-deployment@463dfe08b1b31721b73459a02417eae59198fc93 # v1.0.13
         with:
           ref-openvidu-local-deployment: development
           pre_startup_commands: |
@@ -54,5 +54,5 @@ jobs:
           retention-days: 7
       - name: Cleanup
         if: always()
-        uses: OpenVidu/actions/cleanup@9a2f61e73052475bd4572ce2f3a574476a37eae5 # v1.0.8
+        uses: OpenVidu/actions/cleanup@463dfe08b1b31721b73459a02417eae59198fc93 # v1.0.13
 


### PR DESCRIPTION
Updates pinned references of `OpenVidu/actions` to `v1.0.13`.

Auto-generated by the [update-pinned-actions](https://github.com/OpenVidu/actions/actions/workflows/update-pinned-actions.yml) workflow.