### PR TITLE
chore: update OpenVidu/actions to v1.0.21

### DIFF
--- a/.github/workflows/openvidu-components-angular-tests.yml
+++ b/.github/workflows/openvidu-components-angular-tests.yml
@@ -35,7 +35,7 @@ jobs:
         with:
           node-version: ${{ env.NODE_VERSION }}
       - name: Install safe-chain
-        uses: OpenVidu/actions/install-safe-chain@1eb0c5759951f915de29647dedfa1ec8fbb5eeac # v1.0.20
+        uses: OpenVidu/actions/install-safe-chain@040cbfd01320475801d7b12e33769e0d55a737a8 # v1.0.21
       - name: Commit URL
         run: echo https://github.com/OpenVidu/openvidu/commit/${{ inputs.commit_sha || github.sha }}
       - name: Send Dispatch Event
@@ -96,7 +96,7 @@ jobs:
         with:
           node-version: ${{ env.NODE_VERSION }}
       - name: Install safe-chain
-        uses: OpenVidu/actions/install-safe-chain@1eb0c5759951f915de29647dedfa1ec8fbb5eeac # v1.0.20
+        uses: OpenVidu/actions/install-safe-chain@040cbfd01320475801d7b12e33769e0d55a737a8 # v1.0.21
       - name: Install wait-on package
         run: npm install -g wait-on
       - name: Run Chrome
@@ -107,15 +107,15 @@ jobs:
             docker run --network=host -d -p 4444:4444 ${{ env.CHROME_IMAGE }}
           fi
       - name: Run openvidu-local-deployment
-        uses: OpenVidu/actions/start-openvidu-local-deployment@1eb0c5759951f915de29647dedfa1ec8fbb5eeac # v1.0.20
+        uses: OpenVidu/actions/start-openvidu-local-deployment@040cbfd01320475801d7b12e33769e0d55a737a8 # v1.0.21
       - name: Start OpenVidu Call backend
-        uses: OpenVidu/actions/start-openvidu-call@1eb0c5759951f915de29647dedfa1ec8fbb5eeac # v1.0.20
+        uses: OpenVidu/actions/start-openvidu-call@040cbfd01320475801d7b12e33769e0d55a737a8 # v1.0.21
       - name: Build and Serve openvidu-components-angular Testapp
-        uses: OpenVidu/actions/start-openvidu-components-testapp@1eb0c5759951f915de29647dedfa1ec8fbb5eeac # v1.0.20
+        uses: OpenVidu/actions/start-openvidu-components-testapp@040cbfd01320475801d7b12e33769e0d55a737a8 # v1.0.21
       - name: Run Tests
         env:
           LAUNCH_MODE: CI
         run: npm run ${{ matrix.script }} --prefix openvidu-components-angular
       - name: Cleanup
         if: always()
-        uses: OpenVidu/actions/cleanup@1eb0c5759951f915de29647dedfa1ec8fbb5eeac # v1.0.20
+        uses: OpenVidu/actions/cleanup@040cbfd01320475801d7b12e33769e0d55a737a8 # v1.0.21

--- a/.github/workflows/openvidu-integration-tests.yml
+++ b/.github/workflows/openvidu-integration-tests.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Configure OpenVidu Local Deployment
-        uses: OpenVidu/actions/start-openvidu-local-deployment@1eb0c5759951f915de29647dedfa1ec8fbb5eeac # v1.0.20
+        uses: OpenVidu/actions/start-openvidu-local-deployment@040cbfd01320475801d7b12e33769e0d55a737a8 # v1.0.21
         with:
           ref-openvidu-local-deployment: development
           pre_startup_commands: |
@@ -35,7 +35,7 @@ jobs:
         with:
           node-version: 24
       - name: Install safe-chain
-        uses: OpenVidu/actions/install-safe-chain@1eb0c5759951f915de29647dedfa1ec8fbb5eeac # v1.0.20
+        uses: OpenVidu/actions/install-safe-chain@040cbfd01320475801d7b12e33769e0d55a737a8 # v1.0.21
 
       - name: Install dependencies
         working-directory: ./openvidu/openvidu-test-integration
@@ -54,5 +54,5 @@ jobs:
           retention-days: 7
       - name: Cleanup
         if: always()
-        uses: OpenVidu/actions/cleanup@1eb0c5759951f915de29647dedfa1ec8fbb5eeac # v1.0.20
+        uses: OpenVidu/actions/cleanup@040cbfd01320475801d7b12e33769e0d55a737a8 # v1.0.21
 


### PR DESCRIPTION
Updates pinned references of `OpenVidu/actions` to `v1.0.21`.

Auto-generated by the [update-pinned-actions](https://github.com/OpenVidu/actions/actions/workflows/update-pinned-actions.yml) workflow.