### PR TITLE
fix: Unstable Camera Access: "AbortError: Timeout starting video source" on W...

### DIFF
--- a/openvidu-components-angular/projects/openvidu-components-angular/src/lib/services/device/device.service.ts
+++ b/openvidu-components-angular/projects/openvidu-components-angular/src/lib/services/device/device.service.ts
@@ -1,7 +1,8 @@
 import { computed, Injectable, OnDestroy, signal } from '@angular/core';
-import { createLocalTracks, LocalTrack, Room, Track } from 'livekit-client';
+import { createLocalTracks, CreateLocalTracksOptions, LocalTrack, Room, Track } from 'livekit-client';
 import { CameraType, CustomDevice, DeviceType } from '../../models/device.model';
 import { ILogger } from '../../models/logger.model';
+import { retryOnTransientMediaDeviceError } from '../../utils/utils';
 import { LoggerService } from '../logger/logger.service';
 import { PlatformService } from '../platform/platform.service';
 import { StorageService } from '../storage/storage.service';
@@ -207,7 +208,7 @@ export class DeviceService implements OnDestroy {
 		// Strategy 1: Try requesting both together (single prompt)
 		try {
 			this.log.d('Requesting both audio and video permissions together');
-			const tracks = await createLocalTracks({ audio: true, video: true });
+			const tracks = await this.createTracksForPermissionRequest({ audio: true, video: true });
 
 			// Check which tracks we got
 			const videoTrack = tracks.find(t => t.kind === Track.Kind.Video);
@@ -287,7 +288,7 @@ export class DeviceService implements OnDestroy {
 	 */
 	private async requestVideoPermission(): Promise<LocalTrack[]> {
 		try {
-			return await createLocalTracks({ audio: false, video: true });
+			return await this.createTracksForPermissionRequest({ audio: false, video: true });
 		} catch (error: any) {
 			this.videoState.update(state => ({
 				...state,
@@ -303,7 +304,7 @@ export class DeviceService implements OnDestroy {
 	 */
 	private async requestAudioPermission(): Promise<LocalTrack[]> {
 		try {
-			return await createLocalTracks({ audio: true, video: false });
+			return await this.createTracksForPermissionRequest({ audio: true, video: false });
 		} catch (error: any) {
 			this.audioState.update(state => ({
 				...state,
@@ -312,6 +313,14 @@ export class DeviceService implements OnDestroy {
 			}));
 			throw error;
 		}
+	}
+
+	private async createTracksForPermissionRequest(options: CreateLocalTracksOptions): Promise<LocalTrack[]> {
+		return retryOnTransientMediaDeviceError(
+			() => createLocalTracks(options),
+			(error, attempt, delayMs) =>
+				this.log.w(`Transient media device error on attempt ${attempt}, retrying in ${delayMs}ms`, error)
+		);
 	}
 
 	/**

--- a/openvidu-components-angular/projects/openvidu-components-angular/src/lib/services/openvidu/openvidu.service.ts
+++ b/openvidu-components-angular/projects/openvidu-components-angular/src/lib/services/openvidu/openvidu.service.ts
@@ -23,6 +23,7 @@ import {
 	VideoPresets
 } from 'livekit-client';
 import { ILogger } from '../../models/logger.model';
+import { retryOnTransientMediaDeviceError } from '../../utils/utils';
 import { OpenViduComponentsConfigService } from '../config/directive-config.service';
 import { DeviceService } from '../device/device.service';
 import { LoggerService } from '../logger/logger.service';
@@ -508,7 +509,7 @@ export class OpenViduService {
 				newLocalTracks = await this.createTracksWithFallback(options);
 			} else {
 				// Original behavior - all or nothing
-				newLocalTracks = await createLocalTracks(options);
+				newLocalTracks = await this.createTracksWithRetry(options);
 			}
 
 			// Apply background processor to the new video track.
@@ -542,7 +543,7 @@ export class OpenViduService {
 		// Try to create video track separately
 		if (options.video) {
 			try {
-				const videoTracks = await createLocalTracks({ video: options.video });
+				const videoTracks = await this.createTracksWithRetry({ video: options.video });
 				tracks.push(...videoTracks);
 				this.log.d('Video track created successfully');
 			} catch (error) {
@@ -554,7 +555,7 @@ export class OpenViduService {
 		// Try to create audio track separately
 		if (options.audio) {
 			try {
-				const audioTracks = await createLocalTracks({ audio: options.audio });
+				const audioTracks = await this.createTracksWithRetry({ audio: options.audio });
 				tracks.push(...audioTracks);
 				this.log.d('Audio track created successfully');
 			} catch (error) {
@@ -563,6 +564,14 @@ export class OpenViduService {
 		}
 
 		return tracks;
+	}
+
+	private async createTracksWithRetry(options: CreateLocalTracksOptions): Promise<LocalTrack[]> {
+		return retryOnTransientMediaDeviceError(
+			() => createLocalTracks(options),
+			(error, attempt, delayMs) =>
+				this.log.w(`Transient media device error on attempt ${attempt}, retrying in ${delayMs}ms`, error)
+		);
 	}
 
 	private toDeviceConstraint(deviceId?: string): ConstrainDOMString {

--- a/openvidu-components-angular/projects/openvidu-components-angular/src/lib/utils/utils.ts
+++ b/openvidu-components-angular/projects/openvidu-components-angular/src/lib/utils/utils.ts
@@ -5,3 +5,37 @@ export const safeJsonParse = <T = any>(text: string): T | null => {
 		return null;
 	}
 };
+
+const TRANSIENT_MEDIA_DEVICE_ERROR_NAMES = ['AbortError', 'NotReadableError'];
+
+export const isTransientMediaDeviceError = (error: unknown): boolean => {
+	const name = (error as { name?: string } | undefined)?.name;
+	return !!name && TRANSIENT_MEDIA_DEVICE_ERROR_NAMES.includes(name);
+};
+
+export const retryOnTransientMediaDeviceError = async <T>(
+	operation: () => Promise<T>,
+	onRetry?: (error: unknown, attempt: number, delayMs: number) => void,
+	maxAttempts: number = 3,
+	baseDelayMs: number = 400
+): Promise<T> => {
+	let lastError: unknown;
+
+	for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+		try {
+			return await operation();
+		} catch (error) {
+			lastError = error;
+
+			if (attempt === maxAttempts || !isTransientMediaDeviceError(error)) {
+				break;
+			}
+
+			const delayMs = baseDelayMs * attempt;
+			onRetry?.(error, attempt, delayMs);
+			await new Promise((resolve) => setTimeout(resolve, delayMs));
+		}
+	}
+
+	throw lastError;
+};


### PR DESCRIPTION
Fixes #855

## Root cause

Camera acquisition is not retried on transient AbortError ("Timeout starting video source")

## Changes

- Added a shared retry helper for transient media-device errors (AbortError / NotReadableError) with incremental backoff, and routed all livekit createLocalTracks calls used for device permission probing (DeviceService) and local track creation (OpenViduService) through it, so a camera that is still being released by the OS is re-acquired instead of failing. Added unit tests for the helper.